### PR TITLE
Adding base image for Debian Buster

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ images are:
 - `quay.io/footloose/fedora29`
 - `quay.io/footloose/ubuntu18.04`
 - `quay.io/footloose/amazonlinux2`
+- `quay.io/footloose/debian10`
 
 For example:
 

--- a/images/debian10/Dockerfile
+++ b/images/debian10/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:buster
+
+ENV container docker
+
+# Don't start any optional services except for the few we need.
+RUN find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \;
+
+RUN apt-get update && \
+    apt-get install -y \
+    dbus systemd-sysv openssh-server && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 22
+
+RUN systemctl set-default multi-user.target
+RUN systemctl mask \
+    dev-hugepages.mount \
+    sys-fs-fuse-connections.mount \
+    systemd-update-utmp.service \
+    systemd-tmpfiles-setup.service \
+    console-getty.service
+
+# https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/
+STOPSIGNAL SIGRTMIN+3
+
+CMD ["/bin/bash"]

--- a/images/debian10/Dockerfile
+++ b/images/debian10/Dockerfile
@@ -27,6 +27,11 @@ RUN systemctl mask \
     systemd-tmpfiles-setup.service \
     console-getty.service
 
+# This container image doesn't have locales installed. Disable forwarding the
+# user locale env variables or we get warnings such as:
+#  bash: warning: setlocale: LC_ALL: cannot change locale
+RUN sed -i -e 's/^AcceptEnv LANG LC_\*$/#AcceptEnv LANG LC_*/' /etc/ssh/sshd_config
+
 # https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/
 STOPSIGNAL SIGRTMIN+3
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -84,7 +84,8 @@ such a variable. User-defined variables are kept in `variables.json`:
     "amazonlinux2",
     "centos7",
     "fedora29",
-    "ubuntu18.04"
+    "ubuntu18.04",
+    "debian10"
   ]
 }
 ```

--- a/tests/variables.json
+++ b/tests/variables.json
@@ -3,6 +3,7 @@
     "amazonlinux2",
     "centos7",
     "fedora29",
-    "ubuntu18.04"
+    "ubuntu18.04",
+    "debian10"
   ]
 }


### PR DESCRIPTION
Debian 10 "Buster" had a *full freeze* this week (on 2019-03-12) and will be released somewhere later this year (mid 2019).
I thought a base image might come in handy, so here it is.
To be honest it's mostly a copy of `footloose/images/ubuntu18.04`.

Testing done:

```txt
$ ./make-image.sh build debian10

$ footloose config create --image quay.io/footloose/debian10
$ footloose create
INFO[0000] Image: quay.io/footloose/debian10 present locally
INFO[0000] Creating machine: cluster-node0 ...

$ footloose ssh root@node0
Linux node0 4.9.125-linuxkit #1 SMP Fri Sep 7 08:20:28 UTC 2018 x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.

root@node0:~# ps fx
  PID TTY      STAT   TIME COMMAND
    1 ?        Ss     0:00 /sbin/init
   19 ?        Ss     0:00 /lib/systemd/systemd-journald
   25 ?        Ss     0:00 /lib/systemd/systemd-logind
   28 ?        Ss     0:00 /usr/sbin/sshd -D
   49 ?        Ss     0:00  \_ sshd: root@pts/1
   61 pts/1    Ss     0:00      \_ -bash
   64 pts/1    R+     0:00          \_ ps fx
   52 ?        Ss     0:00 /lib/systemd/systemd --user
   53 ?        S      0:00  \_ (sd-pam)
root@node0:~#
```