### PR TITLE
ssh: Specify IdentitiesOnly=yes

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -324,6 +324,7 @@ func (c *Cluster) SSH(nodename string, username string, remoteArgs ...string) er
 	args := []string{
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
+		"-o", "IdentitiesOnly=yes",
 		"-i", c.spec.Cluster.PrivateKey,
 		"-p", f("%d", hostPort),
 		"-l", username,


### PR DESCRIPTION
In some cases, when there are many identities configured client side, the
server may give up on trying all of them and fails with:

  Too many authentication failures

Instruct ssh to only the specified identity.