### PR TITLE
Add a test running docker in docker with debian10

### DIFF
--- a/tests/test-docker-in-docker-debian10.cmd
+++ b/tests/test-docker-in-docker-debian10.cmd
@@ -1,0 +1,6 @@
+footloose create --config %testName.yaml
+footloose --config %testName.yaml ssh root@node0 -- apt update && apt install -y docker.io
+footloose --config %testName.yaml ssh root@node0 systemctl start docker
+footloose --config %testName.yaml ssh root@node0 docker pull busybox
+%out footloose --config %testName.yaml ssh root@node0 docker run busybox echo success
+footloose delete --config %testName.yaml

--- a/tests/test-docker-in-docker-debian10.golden.output
+++ b/tests/test-docker-in-docker-debian10.golden.output
@@ -1,0 +1,1 @@
+success

--- a/tests/test-docker-in-docker-debian10.yaml
+++ b/tests/test-docker-in-docker-debian10.yaml
@@ -1,0 +1,14 @@
+cluster:
+  name: test-docker-in-docker-debian10
+  privateKey: test-docker-in-docker-debian10-key
+machines:
+- count: 1
+  spec:
+    volumes:
+    - type: volume
+      destination: /var/lib/docker
+    image: quay.io/footloose/debian10
+    name: node%d
+    portMappings:
+    - containerPort: 22
+    privileged: true


### PR DESCRIPTION
This will fix #92.

Testing done.

```txt
go test -v -run TestEndToEnd/test-docker-in-docker-debian10
=== RUN   TestEndToEnd
=== RUN   TestEndToEnd/test-docker-in-docker-debian10
INFO[0000] Creating SSH key: test-docker-in-docker-debian10-key ...
INFO[0002] Image: quay.io/footloose/debian10 present locally
INFO[0002] Creating machine: test-docker-in-docker-debian10-node0 ...

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

--- 8< --- cut ---

Status: Downloaded newer image for busybox:latest
INFO[0000] Deleting machine: test-docker-in-docker-debian10-node0 ...
--- PASS: TestEndToEnd (54.73s)
    --- PASS: TestEndToEnd/test-docker-in-docker-debian10 (54.73s)
PASS
ok  	github.com/weaveworks/footloose/tests	54.752s
```