### PR TITLE
version: Add a version command

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print footloose version",
+	Run:   showVersion,
+}
+
+func init() {
+	footloose.AddCommand(versionCmd)
+}
+
+var version = "git"
+
+func showVersion(cmd *cobra.Command, args []string) {
+	fmt.Println("version:", version)
+}


### PR DESCRIPTION
goreleaser should set the version through an ldflag, see:

  https://goreleaser.com/customization/

  default is `-s -w -X main.version={{.Version}} ....`

Fixes: #57