### PR TITLE
Ensure we use a fixed Docker tag in the default configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ deploy:
   script: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" quay.io && ./make-image.sh push all
 - provider: script
   skip_cleanup: true
+  script: ./make-image.sh tag all $TRAVIS_TAG && ./make-image.sh push all $TRAVIS_TAG
+  on:
+    tags: true
+- provider: script
+  skip_cleanup: true
   script: curl -sL https://git.io/goreleaser | bash
   on:
     tags: true

--- a/defaults.go
+++ b/defaults.go
@@ -2,6 +2,14 @@ package main
 
 import "github.com/weaveworks/footloose/pkg/config"
 
+// imageTag computes the docker image tag given the footloose version.
+func imageTag(v string) string {
+	if v == "git" {
+		return "latest"
+	}
+	return v
+}
+
 var defaultConfig = config.Config{
 	Cluster: config.Cluster{
 		Name:       "cluster",
@@ -11,7 +19,7 @@ var defaultConfig = config.Config{
 		Count: 1,
 		Spec: config.Machine{
 			Name:  "node%d",
-			Image: "quay.io/footloose/centos7:0.1.0",
+			Image: "quay.io/footloose/centos7:" + imageTag(version),
 			PortMappings: []config.PortMapping{{
 				ContainerPort: 22,
 			}},


### PR DESCRIPTION
The default image was hardcoded to "0.1.0", with this PR we now use the latest released tag (or "latest" when compiling from git).

Fixes: #99 