### PR TITLE
Expand environment variables for private key file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8u
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -96,7 +96,7 @@ func (c *Cluster) forEachMachine(do func(*Machine, int) error) error {
 }
 
 func (c *Cluster) ensureSSHKey() error {
-	path := c.spec.Cluster.PrivateKey
+	path := os.ExpandEnv(c.spec.Cluster.PrivateKey)
 	if _, err := os.Stat(path); err == nil {
 		return nil
 	}
@@ -121,7 +121,7 @@ touch $sshdir/authorized_keys; chmod 600 $sshdir/authorized_keys
 `
 
 func (c *Cluster) publicKey() ([]byte, error) {
-	return ioutil.ReadFile(c.spec.Cluster.PrivateKey + ".pub")
+	return ioutil.ReadFile(os.ExpandEnv(c.spec.Cluster.PrivateKey) + ".pub")
 }
 
 func (c *Cluster) createMachine(machine *Machine, i int) error {
@@ -510,7 +510,7 @@ func (c *Cluster) SSH(nodename string, username string, remoteArgs ...string) er
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "IdentitiesOnly=yes",
-		"-i", c.spec.Cluster.PrivateKey,
+		"-i", os.ExpandEnv(c.spec.Cluster.PrivateKey),
 		"-p", f("%d", hostPort),
 		"-l", username,
 		remote,

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -12,7 +12,7 @@ type Cluster struct {
 	Name string `json:"name"`
 
 	// PrivateKey is the path to the private SSH key used to login into the cluster
-	// machines.
+	// machines. Can be expanded to user homedir if ~ is found. Ex. ~/.ssh/id_rsa
 	PrivateKey string `json:"privateKey"`
 }
 


### PR DESCRIPTION
This PR enables environment variable expansion for the private key file.

With it one can use an already existing key by passing to the config file:

```yaml
cluster:
  name: cluster
  privateKey: $HOME/.ssh/id_rsa
machines:
- count: 1
...
```