### PR TITLE
Add image for openSUSE / Tumbleweed

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ images are:
 - `quay.io/footloose/ubuntu18.04`
 - `quay.io/footloose/amazonlinux2`
 - `quay.io/footloose/debian10`
+- `quay.io/footloose/opensuse`
 
 For example:
 

--- a/images/opensuse/Dockerfile
+++ b/images/opensuse/Dockerfile
@@ -1,0 +1,24 @@
+FROM opensuse/tumbleweed:latest
+
+RUN zypper -n install systemd; zypper clean ; \
+(cd /usr/lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /usr/lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /usr/lib/systemd/system/local-fs.target.wants/*; \
+rm -f /usr/lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /usr/lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /usr/lib/systemd/system/basic.target.wants/*;\
+rm -f /usr/lib/systemd/system/anaconda.target.wants/*;
+
+RUN zypper --non-interactive install \
+  openssh \
+  sudo hostname iproute2 net-tools iputils wget && \
+  zypper clean
+
+RUN ln -s /bin/systemd /sbin/init
+EXPOSE 22
+
+# https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/
+STOPSIGNAL SIGRTMIN+3
+
+CMD ["bash"]

--- a/tests/variables.json
+++ b/tests/variables.json
@@ -5,6 +5,7 @@
     "fedora29",
     "ubuntu16.04",
     "ubuntu18.04",
-    "debian10"
+    "debian10",
+    "opensuse"
   ]
 }


### PR DESCRIPTION
Adds an image for openSUSE's rolling release named
Tumbleweed.

Tested with footloose create / ssh on a Linux
host.

Fixes: https://github.com/weaveworks/footloose/issues/122

Signed-off-by: Alex Ellis <alexellis2@gmail.com>