### PR TITLE
cluster: Fix the Stopped/Running logic

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -132,8 +132,8 @@ func (c *Cluster) createMachine(machine *Machine, i int) error {
 	// Start the container.
 	log.Infof("Creating machine: %s ...", name)
 
-	if machine.IsRunning() {
-		log.Infof("Machine with name %s is already running...", name)
+	if machine.IsCreated() {
+		log.Infof("Machine with name %s is already created...", name)
 		return nil
 	}
 
@@ -227,8 +227,8 @@ func (c *Cluster) Create() error {
 
 func (c *Cluster) deleteMachine(machine *Machine, i int) error {
 	name := machine.ContainerName()
-	if !machine.IsRunning() {
-		log.Infof("Machine with name %s isn't running...", name)
+	if !machine.IsCreated() {
+		log.Infof("Machine with name %s hasn't been created...", name)
 		return nil
 	}
 
@@ -293,7 +293,7 @@ func (c *Cluster) gatherMachines() (machines []*Machine, err error) {
 	// cluster related data.
 	machines = c.gatherMachinesByCluster()
 	for _, m := range machines {
-		if m.IsRunning() {
+		if m.IsCreated() {
 			inspect, err := c.gatherMachineDetails(m.name)
 			if err != nil {
 				return machines, err
@@ -357,8 +357,8 @@ func (c *Cluster) gatherMachinesByCluster() (machines []*Machine) {
 
 func (c *Cluster) startMachine(machine *Machine, i int) error {
 	name := machine.ContainerName()
-	if !machine.IsRunning() {
-		log.Infof("Machine with name %s isn't running...", name)
+	if !machine.IsCreated() {
+		log.Infof("Machine with name %s hasn't been created...", name)
 		return nil
 	}
 	if machine.IsStarted() {
@@ -384,8 +384,8 @@ func (c *Cluster) Start() error {
 func (c *Cluster) stopMachine(machine *Machine, i int) error {
 	name := machine.ContainerName()
 
-	if !machine.IsRunning() {
-		log.Infof("Machine with name %s isn't running...", name)
+	if !machine.IsCreated() {
+		log.Infof("Machine with name %s hasn't been created...", name)
 		return nil
 	}
 	if !machine.IsStarted() {

--- a/pkg/cluster/formatter.go
+++ b/pkg/cluster/formatter.go
@@ -59,7 +59,7 @@ func (JSONFormatter) Format(machines []*Machine) error {
 		s.Command = m.spec.Cmd
 		s.Spec = m.spec
 		state := "Stopped"
-		if m.IsRunning() {
+		if m.IsStarted() {
 			state = "Running"
 		}
 		s.State = state
@@ -114,7 +114,7 @@ func (TableFormatter) Format(machines []*Machine) error {
 	table.SetHeader([]string{"Name", "Hostname", "Ports", "IP", "Image", "Cmd", "State"})
 	for _, m := range machines {
 		state := Stopped
-		if m.IsRunning() {
+		if m.IsStarted() {
 			state = Running
 		}
 		var ports []string

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -41,8 +41,9 @@ func (m *Machine) Hostname() string {
 	return m.hostname
 }
 
-// IsRunning returns if a machine is currently active and running or not.
-func (m *Machine) IsRunning() bool {
+// IsCreated returns if a machine is has been created. A created machine could
+// either be running or stopped.
+func (m *Machine) IsCreated() bool {
 	res, _ := docker.Inspect(m.name, "{{.Name}}")
 	if len(res) > 0 && len(res[0]) > 0 {
 		return true


### PR DESCRIPTION
Containers follow the OCI lifecycle: create, start, stop, delete.

Currently the IsRunning function tests if the container name exist. This isn't
a condition that tells us if the container is started, only that it's been
created.

- Let's rename IsRunning to IsCreated to reflect that reality.
- Make the formatters use IsStart to decide whether the machine is running or
  not.

Fixes: #114