### PR TITLE
Show/Inspect more generic

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -289,8 +289,8 @@ func (c *Cluster) Delete() error {
 	return c.forEachMachine(c.deleteMachine)
 }
 
-// Show will generate information about running or stopped machines.
-func (c *Cluster) Show(hostnames []string) ([]*Machine, error) {
+// Inspect will generate information about running or stopped machines.
+func (c *Cluster) Inspect(hostnames []string) ([]*Machine, error) {
 	machines, err := c.gatherMachines()
 	if err != nil {
 		return nil, err

--- a/pkg/cluster/formatter.go
+++ b/pkg/cluster/formatter.go
@@ -15,7 +15,7 @@ import (
 // in a given format.
 type Formatter interface {
 	Format([]*Machine) error
-	FormatSingle(Machine) error
+	FormatSingle(*Machine) error
 }
 
 // JSONFormatter formats a slice of machines into a JSON and
@@ -94,8 +94,8 @@ func (JSONFormatter) Format(machines []*Machine) error {
 }
 
 // FormatSingle is a json formatter for a single machine.
-func (js JSONFormatter) FormatSingle(m Machine) error {
-	return js.Format([]*Machine{&m})
+func (js JSONFormatter) FormatSingle(m *Machine) error {
+	return js.Format([]*Machine{m})
 }
 
 type tableMachine struct {
@@ -152,12 +152,12 @@ func (TableFormatter) Format(machines []*Machine) error {
 }
 
 // FormatSingle is a table formatter for a single machine.
-func (TableFormatter) FormatSingle(machine Machine) error {
+func (TableFormatter) FormatSingle(machine *Machine) error {
 	jsonFormatter := JSONFormatter{}
 	return jsonFormatter.FormatSingle(machine)
 }
 
-func getFormatter(output string) (Formatter, error) {
+func GetFormatter(output string) (Formatter, error) {
 	var formatter Formatter
 	switch output {
 	case "json":

--- a/show.go
+++ b/show.go
@@ -32,7 +32,7 @@ func show(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	formatter, err := cluster.GetFormatter(showOptions.output)
-	machines, err := c.Show(args)
+	machines, err := c.Inspect(args)
 	if err != nil {
 		return err
 	}

--- a/show.go
+++ b/show.go
@@ -31,8 +31,10 @@ func show(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if len(args) > 0 {
-		return c.Inspect(args[0])
+	formatter, err := cluster.GetFormatter(showOptions.output)
+	machines, err := c.Show(args)
+	if err != nil {
+		return err
 	}
-	return c.Show(showOptions.output)
+	return formatter.Format(machines)
 }


### PR DESCRIPTION
Making Show/Inspect more generic for future usages.
Merging Show and Inspect in Inspect function. In the future, Show will not be an accurate name for other usages.

Fixes #133 