### PR TITLE
Add sudo to all Docker images

### DIFF
--- a/images/clearlinux/Dockerfile
+++ b/images/clearlinux/Dockerfile
@@ -2,7 +2,7 @@ FROM clearlinux:latest
 
 ENV container docker
 
-RUN swupd bundle-add openssh-server vim network-basic
+RUN swupd bundle-add openssh-server vim network-basic sudo
 RUN echo 'root:*:17995::::::' > /etc/shadow
 
 EXPOSE 22

--- a/images/debian10/Dockerfile
+++ b/images/debian10/Dockerfile
@@ -13,7 +13,7 @@ RUN find /etc/systemd/system \
 
 RUN apt-get update && \
     apt-get install -y \
-    dbus systemd openssh-server net-tools iproute2 iputils-ping curl wget vim-tiny && \
+    dbus systemd openssh-server net-tools iproute2 iputils-ping curl wget vim-tiny sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/ubuntu16.04/Dockerfile
+++ b/images/ubuntu16.04/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/# deb/deb/g' /etc/apt/sources.list
 
 RUN apt-get update \
-    && apt-get install -y systemd dbus openssh-client openssh-server net-tools iproute2 iputils-ping curl wget vim-tiny \
+    && apt-get install -y systemd dbus openssh-client openssh-server net-tools iproute2 iputils-ping curl wget vim-tiny sudo \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/images/ubuntu18.04/Dockerfile
+++ b/images/ubuntu18.04/Dockerfile
@@ -13,7 +13,7 @@ RUN find /etc/systemd/system \
 
 RUN apt-get update && \
     apt-get install -y \
-    dbus systemd openssh-server net-tools iproute2 iputils-ping curl wget vim-tiny && \
+    dbus systemd openssh-server net-tools iproute2 iputils-ping curl wget vim-tiny sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tests/test-basic-commands-%image.cmd
+++ b/tests/test-basic-commands-%image.cmd
@@ -10,4 +10,5 @@ footloose --config %testName.footloose ssh root@node0 -- ping -V
 footloose --config %testName.footloose ssh root@node0 -- curl --version
 footloose --config %testName.footloose ssh root@node0 -- wget --version
 footloose --config %testName.footloose ssh root@node0 -- vi --help
+footloose --config %testName.footloose ssh root@node0 -- sudo true
 footloose delete --config %testName.footloose


### PR DESCRIPTION
This installs the package `sudo` in Ubuntu images by default. Other images already do that; this PR makes ubuntu follow suit.

Fixes: #143 