### PR TITLE
Add status alias to show command

### DIFF
--- a/show.go
+++ b/show.go
@@ -6,8 +6,9 @@ import (
 )
 
 var showCmd = &cobra.Command{
-	Use:   "show [HOSTNAME]",
-	Short: "Show all running machines or a single machine with a given hostname.",
+	Use:     "show [HOSTNAME]",
+	Aliases: []string{"status"},
+	Short:   "Show all running machines or a single machine with a given hostname.",
 	Long: `Provides information about machines created by footloose in JSON or Table format.
 Optionally, provide show with a hostname to look for a specific machine. Exp: 'show node0'.`,
 	RunE: show,


### PR DESCRIPTION
Nothing fancy, just `fotoloose status` alias for `footloose show` command.