### PR TITLE
FOOTLOOSE_CONFIG env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ GO111MODULE=on go get github.com/weaveworks/footloose
 ## Usage
 
 `footloose` reads a description of the *Cluster* of *Machines* to create from a
-file, by default named `footloose.yaml`. The `config` command helps with
-creating the initial config file:
+file, by default named `footloose.yaml`. An alternate name can be specified on
+the command line with the `--config` option or through the `FOOTLOOSE_CONFIG`
+environment variable.
+
+The `config` command helps with creating the initial config file:
 
 ```console
 # Create a footloose.yaml config file. Instruct we want to create 3 machines.

--- a/config_create.go
+++ b/config_create.go
@@ -61,8 +61,8 @@ func configCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if configExists(opts.file) && !opts.override {
+	if configExists(configFile(opts.file)) && !opts.override {
 		return fmt.Errorf("configuration file at %s already exists", opts.file)
 	}
-	return cluster.Save(opts.file)
+	return cluster.Save(configFile(opts.file))
 }

--- a/config_get.go
+++ b/config_get.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 func getConfig(cmd *cobra.Command, args []string) error {
-	c, err := config.NewConfigFromFile(getOptions.config)
+	c, err := config.NewConfigFromFile(configFile(getOptions.config))
 	if err != nil {
 		return err
 	}

--- a/create.go
+++ b/create.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func create(cmd *cobra.Command, args []string) error {
-	cluster, err := cluster.NewFromFile(createOptions.config)
+	cluster, err := cluster.NewFromFile(configFile(createOptions.config))
 	if err != nil {
 		return err
 	}

--- a/delete.go
+++ b/delete.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func delete(cmd *cobra.Command, args []string) error {
-	cluster, err := cluster.NewFromFile(deleteOptions.config)
+	cluster, err := cluster.NewFromFile(configFile(deleteOptions.config))
 	if err != nil {
 		return err
 	}

--- a/footloose.go
+++ b/footloose.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,14 @@ var footloose = &cobra.Command{
 	Short:         "footloose - Container Machines",
 	SilenceUsage:  true,
 	SilenceErrors: true,
+}
+
+func configFile(f string) string {
+	env := os.Getenv("FOOTLOOSE_CONFIG")
+	if env != "" && f == Footloose{
+		return env
+	}
+	return f
 }
 
 func main() {

--- a/show.go
+++ b/show.go
@@ -28,7 +28,7 @@ func init() {
 
 // show will show all machines in a given cluster.
 func show(cmd *cobra.Command, args []string) error {
-	c, err := cluster.NewFromFile(showOptions.config)
+	c, err := cluster.NewFromFile(configFile(showOptions.config))
 	if err != nil {
 		return err
 	}

--- a/ssh.go
+++ b/ssh.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 func ssh(cmd *cobra.Command, args []string) error {
-	cluster, err := cluster.NewFromFile(sshOptions.config)
+	cluster, err := cluster.NewFromFile(configFile(sshOptions.config))
 	if err != nil {
 		return err
 	}

--- a/start.go
+++ b/start.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func start(cmd *cobra.Command, args []string) error {
-	cluster, err := cluster.NewFromFile(startOptions.config)
+	cluster, err := cluster.NewFromFile(configFile(startOptions.config))
 	if err != nil {
 		return err
 	}

--- a/stop.go
+++ b/stop.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func stop(cmd *cobra.Command, args []string) error {
-	cluster, err := cluster.NewFromFile(stopOptions.config)
+	cluster, err := cluster.NewFromFile(configFile(stopOptions.config))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It can be handy to specify the config file through an env variable so we don't have to always specify the `--config` option.