### PR TITLE
ensures files in /tmp with executable mode are executable

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -206,7 +206,7 @@ func (c *Cluster) createMachineRunArgs(machine *Machine, name string, i int) []s
 		"--hostname", machine.Hostname(),
 		"--tmpfs", "/run",
 		"--tmpfs", "/run/lock",
-		"--tmpfs", "/tmp",
+		"--tmpfs", "/tmp:exec,mode=777",
 		"-v", "/sys/fs/cgroup:/sys/fs/cgroup:ro",
 	}
 


### PR DESCRIPTION
By default a `tmpfs` mount in Docker will be done with a `noexec` flag, which will prevent files placed on the filesystem from being directly executable.

This is contrary to the way `/tmp` is mounted usually (from a production ubuntu ec2 instance: `tmpfs on /tmp type tmpfs (rw,nosuid,nodev)`, where `noexec` isn't in place.
It avoids placing temporary scripts on /tmp and executing them, which a number of installers are making use off.
My proposed change ensures, that files placed on `/tmp` with executable flag can be run from there, just like they can on a traditional server.

I'd perhaps even like mounts to be somewhat configurable down the road to ensure higher compatibility with different distributions. For now, this shall get my current issue out the way though 👌
Thank you for footloose!