### PR TITLE
added support for used-defined networks and example how to use it.

### DIFF
--- a/examples/user-defined-network/README.md
+++ b/examples/user-defined-network/README.md
@@ -1,0 +1,79 @@
+# Using user-defined network example
+
+Using a user-defined network enables DNS name resolution of the container names, so you can talk
+to each container of the cluster just using the hostname.
+
+First prepare your deploy setup. Notice the line 'network' which specifies which user-defined network the containers should be attached to.
+
+```console
+$ cat footloose_config_example_network.yaml
+
+cluster:
+  name: cluster
+  privateKey: cluster-key
+machines:
+- count: 3
+  spec:
+    image: quay.io/footloose/centos7:0.4.0
+    name: node%d
+    network: footloose-cluster
+    portMappings:
+    - containerPort: 22
+```
+
+The user-defined network has to be created manually before deploying your cluster.
+
+```console
+$ docker network create footloose-cluster
+
+c558b7218393a2e4c89b19f7904d244192664997f46eb6edfc3217e187472afc
+```
+
+now you can deploy your cluster:
+
+```console
+$ footloose create
+
+INFO[0000] Image: quay.io/footloose/centos7 present locally 
+INFO[0000] Creating machine: cluster-node0 ...          
+INFO[0001] Creating machine: cluster-node1 ...  
+INFO[0002] Creating machine: cluster-node2 ...           
+
+```
+
+you now have three containers running, which can talk to each other using their hostnames.
+
+```console
+$ footloose ssh root@node0
+
+[root@node0 ~]# ping -c 4 node1
+PING node1 (172.25.0.3) 56(84) bytes of data.
+64 bytes from cluster-node1.footloose-cluster (172.25.0.3): icmp_seq=1 ttl=64 time=0.240 ms
+64 bytes from cluster-node1.footloose-cluster (172.25.0.3): icmp_seq=2 ttl=64 time=0.289 ms
+64 bytes from cluster-node1.footloose-cluster (172.25.0.3): icmp_seq=3 ttl=64 time=0.193 ms
+64 bytes from cluster-node1.footloose-cluster (172.25.0.3): icmp_seq=4 ttl=64 time=0.205 ms
+
+--- node1 ping statistics ---
+4 packets transmitted, 4 received, 0% packet loss, time 3044ms
+rtt min/avg/max/mdev = 0.193/0.231/0.289/0.041 ms
+[root@node0 ~]# ping -c 4 node2
+PING node2 (172.25.0.4) 56(84) bytes of data.
+64 bytes from cluster-node2.footloose-cluster (172.25.0.4): icmp_seq=1 ttl=64 time=0.109 ms
+64 bytes from cluster-node2.footloose-cluster (172.25.0.4): icmp_seq=2 ttl=64 time=0.184 ms
+64 bytes from cluster-node2.footloose-cluster (172.25.0.4): icmp_seq=3 ttl=64 time=0.143 ms
+
+--- node2 ping statistics ---
+3 packets transmitted, 3 received, 0% packet loss, time 2059ms
+rtt min/avg/max/mdev = 0.109/0.145/0.184/0.032 ms
+
+```
+
+when finished, clean up:
+
+```console
+$ footloose delete
+INFO[0000] Deleting machine: cluster-node0 ...          
+INFO[0000] Deleting machine: cluster-node1 ...   
+INFO[0001] Deleting machine: cluster-node2 ...    
+```
+

--- a/examples/user-defined-network/footloose_config_example_network.yaml
+++ b/examples/user-defined-network/footloose_config_example_network.yaml
@@ -1,0 +1,11 @@
+cluster:
+  name: cluster
+  privateKey: cluster-key
+machines:
+- count: 3
+  spec:
+    image: quay.io/footloose/centos7:0.4.0
+    name: node%d
+    network: footloose-cluster
+    portMappings:
+    - containerPort: 22

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -241,6 +241,11 @@ func (c *Cluster) createMachineRunArgs(machine *Machine, name string, i int) []s
 		runArgs = append(runArgs, "--privileged")
 	}
 
+	if machine.spec.Network != "" {
+		runArgs = append(runArgs, "--network", machine.spec.Network)
+		runArgs = append(runArgs, "--network-alias", machine.Hostname())
+	}
+
 	return runArgs
 }
 

--- a/pkg/config/machine.go
+++ b/pkg/config/machine.go
@@ -53,6 +53,10 @@ type Machine struct {
 	Privileged bool `json:"privileged,omitempty"`
 	// Volumes is the list of volumes attached to this machine.
 	Volumes []Volume `json:"volumes,omitempty"`
+	// Network is the user-defined docker network this machine is attached to.
+	// This network has to be created manually before creating the containers
+	// via "docker network create mynetwork"
+	Network string `json:"network,omitempty"`
 	// PortMappings is the list of ports to expose to the host.
 	PortMappings []PortMapping `json:"portMappings,omitempty"`
 	// Cmd is a cmd which will be run in the container.


### PR DESCRIPTION
This implements https://github.com/weaveworks/footloose/issues/158
The config file has to be edited manually, also the docker network has first to be created by the user before starting the cluster, otherwise you'll receive a docker daemon error.