### PR TITLE
Clear out /etc/machine-id and /var/lib/dbus/machine-id after installing systemd

### DIFF
--- a/images/ubuntu16.04/Dockerfile
+++ b/images/ubuntu16.04/Dockerfile
@@ -19,6 +19,9 @@ RUN find /etc/systemd/system \
     -not -name '*systemd-user-sessions*' \
     -exec rm \{} \;
 
+RUN >/etc/machine-id
+RUN >/var/lib/dbus/machine-id
+
 EXPOSE 22
 
 RUN systemctl set-default multi-user.target

--- a/images/ubuntu18.04/Dockerfile
+++ b/images/ubuntu18.04/Dockerfile
@@ -17,6 +17,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN >/etc/machine-id
+RUN >/var/lib/dbus/machine-id
+
 EXPOSE 22
 
 RUN systemctl set-default multi-user.target


### PR DESCRIPTION
Resolves #154 

If /etc/machine-id is empty at container start, we get distinct machine ids across containers.