### PR TITLE
Update and fix Ignite backend support in Footloose

### DIFF
--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/pkg/errors"
-
+	log "github.com/sirupsen/logrus"
 	"github.com/weaveworks/footloose/pkg/config"
 	"github.com/weaveworks/footloose/pkg/docker"
 	"github.com/weaveworks/footloose/pkg/exec"
@@ -107,6 +108,12 @@ func (m *Machine) HostPort(containerPort int) (hostPort int, err error) {
 	return m.ports[containerPort], nil
 }
 
-func (m *Machine) IsIgnite() bool {
-	return m.spec.Backend == ignite.IgniteName
+func (m *Machine) IsIgnite() (b bool) {
+	b = m.spec.Backend == ignite.IgniteName
+
+	if b && syscall.Getuid() != 0 {
+		log.Fatalf("Footloose needs to run as root to use the %q backend", ignite.IgniteName)
+	}
+
+	return
 }

--- a/pkg/ignite/create.go
+++ b/pkg/ignite/create.go
@@ -23,13 +23,13 @@ func Create(name string, spec *config.Machine, pubKeyPath string) (id string, er
 		fmt.Sprintf("--memory=%s", spec.IgniteConfig().Memory),
 		fmt.Sprintf("--size=%s", spec.IgniteConfig().Disk),
 		fmt.Sprintf("--kernel-image=%s", spec.IgniteConfig().Kernel),
+		fmt.Sprintf("--ssh=%s", pubKeyPath),
 	}
 
 	copyFiles := spec.IgniteConfig().CopyFiles
 	if copyFiles == nil {
 		copyFiles = make(map[string]string)
 	}
-	copyFiles[pubKeyPath] = "/root/.ssh/authorized_keys"
 	for _, v := range setupCopyFiles(copyFiles) {
 		runArgs = append(runArgs, v)
 	}

--- a/pkg/ignite/create.go
+++ b/pkg/ignite/create.go
@@ -12,6 +12,10 @@ const (
 	IgniteName = "ignite"
 )
 
+// This offset is incremented for each port so we avoid
+// duplicate port bindings (and hopefully port collisions).
+var portOffset uint16
+
 // Create creates a container with "docker create", with some error handling
 // it will return the ID of the created container if any, even on error
 func Create(name string, spec *config.Machine, pubKeyPath string) (id string, err error) {
@@ -42,6 +46,10 @@ func Create(name string, spec *config.Machine, pubKeyPath string) (id string, er
 			if mapping.HostPort, err = freePort(); err != nil {
 				return "", err
 			}
+		} else {
+			// If defined, apply an offset so all VMs won't use the same port
+			mapping.HostPort += portOffset
+			portOffset++
 		}
 
 		runArgs = append(runArgs, fmt.Sprintf("--ports=%d:%d", int(mapping.HostPort), mapping.ContainerPort))

--- a/pkg/ignite/create.go
+++ b/pkg/ignite/create.go
@@ -2,6 +2,7 @@ package ignite
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/weaveworks/footloose/pkg/config"
 	"github.com/weaveworks/footloose/pkg/exec"
@@ -34,12 +35,16 @@ func Create(name string, spec *config.Machine, pubKeyPath string) (id string, er
 		runArgs = append(runArgs, v)
 	}
 
-	for i, mapping := range spec.PortMappings {
+	for _, mapping := range spec.PortMappings {
 		if mapping.HostPort == 0 {
-			// TODO: should warn here as containerPort is dropped
-			continue
+			// If not defined, set the host port to a random free ephemeral port
+			var err error
+			if mapping.HostPort, err = freePort(); err != nil {
+				return "", err
+			}
 		}
-		runArgs = append(runArgs, fmt.Sprintf("--ports=%d:%d", int(mapping.HostPort)+i, mapping.ContainerPort))
+
+		runArgs = append(runArgs, fmt.Sprintf("--ports=%d:%d", int(mapping.HostPort), mapping.ContainerPort))
 	}
 
 	_, err = exec.ExecuteCommand(execName, runArgs...)
@@ -56,9 +61,26 @@ func setupCopyFiles(copyFiles map[string]string) []string {
 }
 
 func IsCreated(name string) bool {
-	exitCode, err := exec.ExecForeground(execName, "logs", name)
-	if err != nil || exitCode != 0 {
+	_, err := exec.ExecuteCommand(execName, "logs", name)
+	if err != nil {
 		return false
 	}
 	return true
+}
+
+// freePort requests a free/open ephemeral port from the kernel
+// Heavily inspired by https://github.com/phayes/freeport/blob/master/freeport.go
+func freePort() (uint16, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+
+	return uint16(l.Addr().(*net.TCPAddr).Port), nil
 }


### PR DESCRIPTION
Updates Footloose's interface to `ignite`, adds a root check and implements more robust port map handling for Ignite VMs started via Footloose.