### PR TITLE
Long running footloose server and control API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       - ./make-image.sh build all
       - go install
       - golangci-lint run ./...
+      - go test -timeout 0 -v .
+      - go test -timeout 0 -v ./pkg/...
       - go test -timeout 0 -v ./tests
 
 deploy:

--- a/defaults.go
+++ b/defaults.go
@@ -10,6 +10,9 @@ func imageTag(v string) string {
 	return v
 }
 
+// defaultKeyStore is the path where to store the public keys.
+const defaultKeyStorePath = "keys"
+
 var defaultConfig = config.Config{
 	Cluster: config.Cluster{
 		Name:       "cluster",

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-github/v24 v24.0.1
+	github.com/gorilla/mux v1.7.3
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/google/go-github/v24 v24.0.1 h1:KCt1LjMJEey1qvPXxa9SjaWxwTsCWSq6p2Ju5
 github.com/google/go-github/v24 v24.0.1/go.mod h1:CRqaW1Uns1TCkP0wqTpxYyRxRjxwvKU/XSS44u6X74M=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,17 +1,22 @@
 package api
 
-import "github.com/gorilla/mux"
+import (
+	"github.com/gorilla/mux"
+	"github.com/weaveworks/footloose/pkg/cluster"
+)
 
 // API represents the footloose REST API.
 type API struct {
-	BaseURI string
-	db      db
+	BaseURI  string
+	db       db
+	keyStore *cluster.KeyStore
 }
 
 // New creates a new object able to answer footloose REST API.
 func New(baseURI string) *API {
 	api := &API{
-		BaseURI: baseURI,
+		BaseURI:  baseURI,
+		keyStore: cluster.NewKeyStore("."),
 	}
 	api.db.init()
 	return api
@@ -20,6 +25,9 @@ func New(baseURI string) *API {
 // Router returns the API request router.
 func (a *API) Router() *mux.Router {
 	router := mux.NewRouter()
+	router.HandleFunc("/api/keys", a.createPublicKey).Methods("POST")
+	router.HandleFunc("/api/keys/{key}", a.getPublicKey).Methods("GET")
+	router.HandleFunc("/api/keys/{key}", a.deletePublicKey).Methods("DELETE")
 	router.HandleFunc("/api/clusters", a.createCluster).Methods("POST")
 	router.HandleFunc("/api/clusters/{cluster}", a.deleteCluster).Methods("DELETE")
 	router.HandleFunc("/api/clusters/{cluster}/machines", a.createMachine).Methods("POST")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,16 @@
+package api
+
+// API represents the footloose REST API.
+type API struct {
+	BaseURI string
+	db      db
+}
+
+// New creates a new object able to answer footloose REST API.
+func New(baseURI string) *API {
+	api := &API{
+		BaseURI: baseURI,
+	}
+	api.db.init()
+	return api
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,5 +1,7 @@
 package api
 
+import "github.com/gorilla/mux"
+
 // API represents the footloose REST API.
 type API struct {
 	BaseURI string
@@ -13,4 +15,14 @@ func New(baseURI string) *API {
 	}
 	api.db.init()
 	return api
+}
+
+// Router returns the API request router.
+func (a *API) Router() *mux.Router {
+	router := mux.NewRouter()
+	router.HandleFunc("/api/clusters", a.createCluster).Methods("POST")
+	router.HandleFunc("/api/clusters/{cluster}", a.deleteCluster).Methods("DELETE")
+	router.HandleFunc("/api/clusters/{cluster}/machines", a.createMachine).Methods("POST")
+	router.HandleFunc("/api/clusters/{cluster}/machines/{machine}", a.deleteMachine).Methods("DELETE")
+	return router
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -16,7 +16,7 @@ type API struct {
 func New(baseURI string) *API {
 	api := &API{
 		BaseURI:  baseURI,
-		keyStore: cluster.NewKeyStore("."),
+		keyStore: cluster.NewKeyStore("keys"),
 	}
 	api.db.init()
 	return api

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -31,6 +31,7 @@ func (a *API) Router() *mux.Router {
 	router.HandleFunc("/api/clusters", a.createCluster).Methods("POST")
 	router.HandleFunc("/api/clusters/{cluster}", a.deleteCluster).Methods("DELETE")
 	router.HandleFunc("/api/clusters/{cluster}/machines", a.createMachine).Methods("POST")
+	router.HandleFunc("/api/clusters/{cluster}/machines/{machine}", a.getMachine).Methods("GET")
 	router.HandleFunc("/api/clusters/{cluster}/machines/{machine}", a.deleteMachine).Methods("DELETE")
 	return router
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -13,10 +13,10 @@ type API struct {
 }
 
 // New creates a new object able to answer footloose REST API.
-func New(baseURI string) *API {
+func New(baseURI string, keyStore *cluster.KeyStore) *API {
 	api := &API{
 		BaseURI:  baseURI,
-		keyStore: cluster.NewKeyStore("keys"),
+		keyStore: keyStore,
 	}
 	api.db.init()
 	return api

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -33,6 +33,7 @@ func (a *API) createCluster(w http.ResponseWriter, r *http.Request) {
 		sendError(w, http.StatusInternalServerError, err)
 		return
 	}
+	cluster.SetKeyStore(a.keyStore)
 
 	if err := a.db.addCluster(def.Name, cluster); err != nil {
 		sendError(w, http.StatusBadRequest, err)

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	"github.com/weaveworks/footloose/pkg/cluster"
+	"github.com/weaveworks/footloose/pkg/config"
+)
+
+// ClusterURI returns the URI identifying a cluster in the REST API.
+func (a *API) ClusterURI(c *cluster.Cluster) string {
+	return fmt.Sprintf("%s/api/clusters/%s", a.BaseURI, c.Name())
+}
+
+// CreateCluster creates a cluster.
+func (a *API) CreateCluster(w http.ResponseWriter, r *http.Request) {
+	var def config.Cluster
+	if err := json.NewDecoder(r.Body).Decode(&def); err != nil {
+		sendError(w, http.StatusBadRequest, errors.Wrap(err, "could not decode body"))
+		return
+	}
+	if def.Name == "" {
+		sendError(w, http.StatusBadRequest, errors.New("no cluster name provided"))
+		return
+	}
+
+	cluster, err := cluster.New(config.Config{Cluster: def})
+	if err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	if err := a.db.addCluster(def.Name, cluster); err != nil {
+		sendError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if err := cluster.Create(); err != nil {
+		a.db.removeCluster(def.Name)
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+	sendCreated(w, a.ClusterURI((cluster)))
+}
+
+// DeleteCluster deletes a cluster.
+func (a *API) DeleteCluster(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	c, err := a.db.cluster(vars["cluster"])
+	if err != nil {
+		sendError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	// Starts by deleting the machines associated with the cluster.
+	machines, err := a.db.machines(vars["cluster"])
+	for _, m := range machines {
+		if err := c.DeleteMachine(m, 0); err != nil {
+			sendError(w, http.StatusInternalServerError, err)
+			return
+		}
+		if _, err := a.db.removeMachine(vars["cluster"], m.Hostname()); err != nil {
+			sendError(w, http.StatusInternalServerError, err)
+			return
+		}
+	}
+
+	// Delete cluster.
+	if err := c.Delete(); err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	_, err = a.db.removeCluster(vars["cluster"])
+	if err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	sendOK(w)
+}

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -16,8 +16,8 @@ func (a *API) ClusterURI(c *cluster.Cluster) string {
 	return fmt.Sprintf("%s/api/clusters/%s", a.BaseURI, c.Name())
 }
 
-// CreateCluster creates a cluster.
-func (a *API) CreateCluster(w http.ResponseWriter, r *http.Request) {
+// createCluster creates a cluster.
+func (a *API) createCluster(w http.ResponseWriter, r *http.Request) {
 	var def config.Cluster
 	if err := json.NewDecoder(r.Body).Decode(&def); err != nil {
 		sendError(w, http.StatusBadRequest, errors.Wrap(err, "could not decode body"))
@@ -47,8 +47,8 @@ func (a *API) CreateCluster(w http.ResponseWriter, r *http.Request) {
 	sendCreated(w, a.ClusterURI((cluster)))
 }
 
-// DeleteCluster deletes a cluster.
-func (a *API) DeleteCluster(w http.ResponseWriter, r *http.Request) {
+// deleteCluster deletes a cluster.
+func (a *API) deleteCluster(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	c, err := a.db.cluster(vars["cluster"])
 	if err != nil {

--- a/pkg/api/cluster.go
+++ b/pkg/api/cluster.go
@@ -40,7 +40,7 @@ func (a *API) createCluster(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := cluster.Create(); err != nil {
-		a.db.removeCluster(def.Name)
+		_, _ = a.db.removeCluster(def.Name)
 		sendError(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -58,6 +58,10 @@ func (a *API) deleteCluster(w http.ResponseWriter, r *http.Request) {
 
 	// Starts by deleting the machines associated with the cluster.
 	machines, err := a.db.machines(vars["cluster"])
+	if err != nil {
+		sendError(w, http.StatusBadRequest, err)
+		return
+	}
 	for _, m := range machines {
 		if err := c.DeleteMachine(m, 0); err != nil {
 			sendError(w, http.StatusInternalServerError, err)

--- a/pkg/api/db.go
+++ b/pkg/api/db.go
@@ -1,0 +1,144 @@
+package api
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/weaveworks/footloose/pkg/cluster"
+)
+
+type entry struct {
+	cluster  *cluster.Cluster
+	machines map[string]*cluster.Machine
+}
+
+type db struct {
+	sync.Mutex
+
+	clusters map[string]entry
+}
+
+func (db *db) init() {
+	db.clusters = make(map[string]entry)
+}
+
+func (db *db) entry(name string) *entry {
+	db.Lock()
+	defer db.Unlock()
+
+	entry, ok := db.clusters[name]
+	if !ok {
+		return nil
+	}
+	return &entry
+}
+
+func (db *db) cluster(name string) (*cluster.Cluster, error) {
+	entry := db.entry(name)
+	if entry == nil {
+		return nil, errors.Errorf("unknown cluster '%s'", name)
+	}
+	return entry.cluster, nil
+}
+
+func (db *db) addCluster(name string, c *cluster.Cluster) error {
+	db.Lock()
+	defer db.Unlock()
+
+	if _, ok := db.clusters[name]; ok {
+		return errors.Errorf("cluster '%s' has already been added", name)
+	}
+	db.clusters[name] = entry{
+		cluster:  c,
+		machines: make(map[string]*cluster.Machine),
+	}
+	return nil
+}
+
+func (db *db) removeCluster(name string) (*cluster.Cluster, error) {
+	db.Lock()
+	defer db.Unlock()
+
+	var entry entry
+	var ok bool
+	if entry, ok = db.clusters[name]; !ok {
+		return nil, errors.Errorf("unknown cluster '%s'", name)
+	}
+	// It is an error to remove the cluster from the db before removing all of its
+	// machines.
+	if len(entry.machines) != 0 {
+		return nil, errors.Errorf("cluster has machines associated with it")
+	}
+	delete(db.clusters, name)
+	return entry.cluster, nil
+}
+
+func (db *db) machine(clusterName, machineName string) (*cluster.Machine, error) {
+	entry := db.entry(clusterName)
+	if entry == nil {
+		return nil, errors.Errorf("unknown cluster '%s'", clusterName)
+	}
+
+	db.Lock()
+	defer db.Unlock()
+
+	var m *cluster.Machine
+	var ok bool
+	if m, ok = entry.machines[machineName]; !ok {
+		return nil, errors.Errorf("unknown machine '%s' for cluster '%s'", machineName, clusterName)
+	}
+	return m, nil
+}
+
+func (db *db) machines(clusterName string) ([]*cluster.Machine, error) {
+	entry := db.entry(clusterName)
+	if entry == nil {
+		return nil, errors.Errorf("unknown cluster '%s'", clusterName)
+	}
+
+	db.Lock()
+	defer db.Unlock()
+
+	var machines []*cluster.Machine
+	for _, m := range entry.machines {
+		machines = append(machines, m)
+	}
+	return machines, nil
+}
+
+func (db *db) addMachine(cluster string, m *cluster.Machine) error {
+	entry := db.entry(cluster)
+	if entry == nil {
+		return errors.Errorf("unknown cluster '%s'", cluster)
+	}
+
+	db.Lock()
+	defer db.Unlock()
+
+	// Hostname is really the machine unique name as we don't allow setting a
+	// different hostname.
+	if _, ok := entry.machines[m.Hostname()]; ok {
+		return errors.Errorf("machine '%s' has already been added", m.Hostname())
+
+	}
+	entry.machines[m.Hostname()] = m
+	return nil
+}
+
+func (db *db) removeMachine(clusterName, machineName string) (*cluster.Machine, error) {
+	entry := db.entry(clusterName)
+	if entry == nil {
+		return nil, errors.Errorf("unknown cluster '%s'", clusterName)
+	}
+
+	db.Lock()
+	defer db.Unlock()
+
+	var m *cluster.Machine
+	var ok bool
+	if m, ok = entry.machines[machineName]; !ok {
+		return nil, errors.Errorf("unknown machine '%s' for cluster '%s'", machineName, clusterName)
+	}
+	delete(entry.machines, machineName)
+	return m, nil
+}

--- a/pkg/api/key.go
+++ b/pkg/api/key.go
@@ -27,6 +27,7 @@ func (a *API) createPublicKey(w http.ResponseWriter, r *http.Request) {
 
 	if err := a.keyStore.Store(def.Name, def.Key); err != nil {
 		sendError(w, http.StatusBadRequest, err)
+		return
 	}
 
 	sendCreated(w, a.keyURI(def.Name))

--- a/pkg/api/key.go
+++ b/pkg/api/key.go
@@ -49,11 +49,6 @@ func (a *API) getPublicKey(w http.ResponseWriter, r *http.Request) {
 		sendError(w, http.StatusInternalServerError, err)
 		return
 	}
-
-	if err != nil {
-		sendError(w, http.StatusInternalServerError, err)
-		return
-	}
 }
 
 func (a *API) deletePublicKey(w http.ResponseWriter, r *http.Request) {

--- a/pkg/api/key.go
+++ b/pkg/api/key.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	"github.com/weaveworks/footloose/pkg/config"
+)
+
+func (a *API) keyURI(name string) string {
+	return fmt.Sprintf("%s/keys/%s", a.BaseURI, name)
+}
+
+func (a *API) createPublicKey(w http.ResponseWriter, r *http.Request) {
+	var def config.PublicKey
+	if err := json.NewDecoder(r.Body).Decode(&def); err != nil {
+		sendError(w, http.StatusBadRequest, errors.Wrap(err, "could not decode body"))
+		return
+	}
+	if def.Name == "" {
+		sendError(w, http.StatusBadRequest, errors.New("no key name provided"))
+		return
+	}
+
+	if err := a.keyStore.Store(def.Name, def.Key); err != nil {
+		sendError(w, http.StatusBadRequest, err)
+	}
+
+	sendCreated(w, a.keyURI(def.Name))
+}
+
+func (a *API) getPublicKey(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	data, err := a.keyStore.Get(vars["key"])
+	if err != nil {
+		sendError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	key := config.PublicKey{
+		Name: vars["key"],
+		Key:  string(data),
+	}
+	if err := json.NewEncoder(w).Encode(&key); err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	if err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+}
+
+func (a *API) deletePublicKey(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	if err := a.keyStore.Remove(vars["key"]); err != nil {
+		sendError(w, http.StatusBadRequest, err)
+		return
+	}
+	sendOK(w)
+}

--- a/pkg/api/machine.go
+++ b/pkg/api/machine.go
@@ -16,8 +16,8 @@ func (a *API) MachineURI(c *cluster.Cluster, m *cluster.Machine) string {
 	return fmt.Sprintf("%s/api/clusters/%s/machines/%s", a.BaseURI, c.Name(), m.Hostname())
 }
 
-// CreateMachine creates a machine.
-func (a *API) CreateMachine(w http.ResponseWriter, r *http.Request) {
+// createMachine creates a machine.
+func (a *API) createMachine(w http.ResponseWriter, r *http.Request) {
 	var def config.Machine
 	if err := json.NewDecoder(r.Body).Decode(&def); err != nil {
 		sendError(w, http.StatusBadRequest, errors.Wrap(err, "could not decode body"))
@@ -50,8 +50,8 @@ func (a *API) CreateMachine(w http.ResponseWriter, r *http.Request) {
 	sendCreated(w, a.MachineURI(c, m))
 }
 
-// DeleteMachine deletes a machine.
-func (a *API) DeleteMachine(w http.ResponseWriter, r *http.Request) {
+// deleteMachine deletes a machine.
+func (a *API) deleteMachine(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	c, err := a.db.cluster(vars["cluster"])
 	if err != nil {

--- a/pkg/api/machine.go
+++ b/pkg/api/machine.go
@@ -50,6 +50,26 @@ func (a *API) createMachine(w http.ResponseWriter, r *http.Request) {
 	sendCreated(w, a.MachineURI(c, m))
 }
 
+// getMachine returns a machine object
+func (a *API) getMachine(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	m, err := a.db.machine(vars["cluster"], vars["machine"])
+	if err != nil {
+		sendError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	formatter, err := cluster.GetFormatter("json")
+	if err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+	if err := formatter.FormatSingle(w, m); err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+}
+
 // deleteMachine deletes a machine.
 func (a *API) deleteMachine(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)

--- a/pkg/api/machine.go
+++ b/pkg/api/machine.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	"github.com/weaveworks/footloose/pkg/cluster"
+	"github.com/weaveworks/footloose/pkg/config"
+)
+
+// MachineURI returns the URI identifying a machine in the REST API.
+func (a *API) MachineURI(c *cluster.Cluster, m *cluster.Machine) string {
+	return fmt.Sprintf("%s/api/clusters/%s/machines/%s", a.BaseURI, c.Name(), m.Hostname())
+}
+
+// CreateMachine creates a machine.
+func (a *API) CreateMachine(w http.ResponseWriter, r *http.Request) {
+	var def config.Machine
+	if err := json.NewDecoder(r.Body).Decode(&def); err != nil {
+		sendError(w, http.StatusBadRequest, errors.Wrap(err, "could not decode body"))
+		return
+	}
+	if def.Name == "" {
+		sendError(w, http.StatusBadRequest, errors.New("no machine name provided"))
+		return
+	}
+
+	vars := mux.Vars(r)
+	c, err := a.db.cluster(vars["cluster"])
+	if err != nil {
+		sendError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	m := c.NewMachine(&def)
+
+	if err := c.CreateMachine(m, 0); err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	if err := a.db.addMachine(vars["cluster"], m); err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	sendCreated(w, a.MachineURI(c, m))
+}
+
+// DeleteMachine deletes a machine.
+func (a *API) DeleteMachine(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	c, err := a.db.cluster(vars["cluster"])
+	if err != nil {
+		sendError(w, http.StatusBadRequest, err)
+		return
+	}
+	m, err := a.db.machine(vars["cluster"], vars["machine"])
+	if err != nil {
+		sendError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	if err := c.DeleteMachine(m, 0); err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	_, err = a.db.removeMachine(vars["cluster"], vars["machine"])
+	if err != nil {
+		sendError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	sendOK(w)
+}

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -20,7 +20,7 @@ func sendError(w http.ResponseWriter, status int, err error) {
 	resp := ErrorResponse{
 		Error: err.Error(),
 	}
-	json.NewEncoder(w).Encode(&resp)
+	_ = json.NewEncoder(w).Encode(&resp)
 }
 
 // CreatedResponse is the response POST entry points return when a resource has been
@@ -35,5 +35,5 @@ func sendCreated(w http.ResponseWriter, URI string) {
 	resp := CreatedResponse{
 		URI: URI,
 	}
-	json.NewEncoder(w).Encode(&resp)
+	_ = json.NewEncoder(w).Encode(&resp)
 }

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func sendOK(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusOK)
+}
+
+// ErrorResponse is the response API entry points return when they encountered an error.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+func sendError(w http.ResponseWriter, status int, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	resp := ErrorResponse{
+		Error: err.Error(),
+	}
+	json.NewEncoder(w).Encode(&resp)
+}
+
+// CreatedResponse is the response POST entry points return when a resource has been
+// successfully created.
+type CreatedResponse struct {
+	URI string `json:"uri"`
+}
+
+func sendCreated(w http.ResponseWriter, URI string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	resp := CreatedResponse{
+		URI: URI,
+	}
+	json.NewEncoder(w).Encode(&resp)
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/weaveworks/footloose/pkg/api"
+	"github.com/weaveworks/footloose/pkg/config"
+)
+
+// Client is a object able to talk a remote footloose API server.
+type Client struct {
+	baseURI string
+	client  *http.Client
+}
+
+// New creates a new Client.
+func New(baseURI string) *Client {
+	return &Client{
+		baseURI: baseURI,
+		client:  &http.Client{},
+	}
+}
+
+func (c *Client) uriFromPath(path string) string {
+	return c.baseURI + path
+}
+
+func (c *Client) clusterURI(name string) string {
+	return fmt.Sprintf("%s/api/clusters/%s", c.baseURI, name)
+}
+
+func (c *Client) machineURI(clusterName, name string) string {
+	return fmt.Sprintf("%s/api/clusters/%s/machines/%s", c.baseURI, clusterName, name)
+}
+
+func apiError(resp *http.Response) error {
+	e := api.ErrorResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(&e); err != nil {
+		return errors.New("could not decode error response")
+	}
+	return errors.New(e.Error)
+}
+
+func (c *Client) create(uri string, data interface{}) error {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return errors.Wrap(err, "post")
+	}
+
+	req, err := http.NewRequest("POST", uri, bytes.NewBuffer(jsonData))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "post")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return errors.Wrap(apiError(resp), "post")
+	}
+	return nil
+}
+
+func (c *Client) delete(uri string) error {
+	req, err := http.NewRequest("DELETE", uri, http.NoBody)
+	if err != nil {
+		return errors.Wrap(err, "delete")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "delete")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.Wrap(apiError(resp), "delete")
+	}
+	return nil
+}
+
+// CreateCluster creates a new cluster.
+func (c *Client) CreateCluster(def *config.Cluster) error {
+	return c.create(c.uriFromPath("/api/clusters"), def)
+}
+
+// DeleteCluster deletes a cluster and all its associated machines.
+func (c *Client) DeleteCluster(name string) error {
+	return c.delete(c.clusterURI(name))
+}
+
+// CreateMachine creates a new machine.
+func (c *Client) CreateMachine(cluster string, def *config.Machine) error {
+	return c.create(c.uriFromPath(fmt.Sprintf("/api/clusters/%s/machines", cluster)), def)
+}
+
+// DeleteMachine deletes a machine.
+func (c *Client) DeleteMachine(cluster, machine string) error {
+	return c.delete(c.machineURI(cluster, machine))
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -52,6 +52,9 @@ func (c *Client) create(uri string, data interface{}) error {
 	}
 
 	req, err := http.NewRequest("POST", uri, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return errors.Wrapf(err, "new request to %q", uri)
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.client.Do(req)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -48,23 +48,23 @@ func apiError(resp *http.Response) error {
 func (c *Client) create(uri string, data interface{}) error {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		return errors.Wrap(err, "post")
+		return errors.Wrap(err, "json marshal")
 	}
 
 	req, err := http.NewRequest("POST", uri, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return errors.Wrapf(err, "new request to %q", uri)
+		return errors.Wrapf(err, "new POST request to %q", uri)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "post")
+		return errors.Wrap(err, "http request")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return errors.Wrap(apiError(resp), "post")
+		return errors.Wrapf(apiError(resp), "POST status %d", resp.StatusCode)
 	}
 	return nil
 }
@@ -72,16 +72,16 @@ func (c *Client) create(uri string, data interface{}) error {
 func (c *Client) delete(uri string) error {
 	req, err := http.NewRequest("DELETE", uri, http.NoBody)
 	if err != nil {
-		return errors.Wrap(err, "delete")
+		return errors.Wrapf(err, "new DELETE request to %q", uri)
 	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "delete")
+		return errors.Wrap(err, "http request")
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(apiError(resp), "delete")
+		return errors.Wrapf(apiError(resp), "DELETE status %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaveworks/footloose/pkg/api"
+	"github.com/weaveworks/footloose/pkg/cluster"
 	"github.com/weaveworks/footloose/pkg/config"
 )
 
@@ -150,6 +151,16 @@ func (c *Client) DeleteCluster(name string) error {
 // CreateMachine creates a new machine.
 func (c *Client) CreateMachine(cluster string, def *config.Machine) error {
 	return c.create(c.uriFromPath(fmt.Sprintf("/api/clusters/%s/machines", cluster)), def)
+}
+
+// GetMachine retrieves the machine details.
+//
+// XXX: This API isn't stable and will change in the future as we refine what
+// the machine spec and status objects should be.
+func (c *Client) GetMachine(clusterName, machine string) (*cluster.MachineStatus, error) {
+	status := cluster.MachineStatus{}
+	err := c.get(c.machineURI(clusterName, machine), &status)
+	return &status, err
 }
 
 // DeleteMachine deletes a machine.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,10 +27,12 @@ func newEnv() *env {
 	server.Config.Handler = api.Router()
 	server.Start()
 
+	u, _ := url.Parse(server.URL)
+
 	return &env{
 		server: server,
 		client: Client{
-			baseURI: server.URL,
+			baseURI: u,
 			client:  server.Client(),
 		},
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,76 @@
+package client
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/footloose/pkg/api"
+	"github.com/weaveworks/footloose/pkg/config"
+)
+
+type env struct {
+	server *httptest.Server
+	client Client
+}
+
+func (e *env) Close() {
+	e.server.Close()
+}
+
+func newEnv() *env {
+	// Create an API server
+	server := httptest.NewUnstartedServer(nil)
+	baseURI := "http://" + server.Listener.Addr().String()
+	api := api.New(baseURI)
+	server.Config.Handler = api.Router()
+	server.Start()
+
+	return &env{
+		server: server,
+		client: Client{
+			baseURI: server.URL,
+			client:  server.Client(),
+		},
+	}
+}
+
+func TestCreateDeleteCluster(t *testing.T) {
+	env := newEnv()
+	defer env.Close()
+
+	err := env.client.CreateCluster(&config.Cluster{
+		Name:       "testcluster",
+		PrivateKey: "testcluster-key",
+	})
+	assert.NoError(t, err)
+
+	err = env.client.DeleteCluster("testcluster")
+	assert.NoError(t, err)
+}
+
+func TestCreateDeleteMachine(t *testing.T) {
+	env := newEnv()
+	defer env.Close()
+
+	err := env.client.CreateCluster(&config.Cluster{
+		Name:       "testcluster",
+		PrivateKey: "testcluster-key",
+	})
+	assert.NoError(t, err)
+
+	err = env.client.CreateMachine("testcluster", &config.Machine{
+		Name:  "testmachine",
+		Image: "quay.io/footloose/centos7:latest",
+		PortMappings: []config.PortMapping{
+			{ContainerPort: 22},
+		},
+	})
+	assert.NoError(t, err)
+
+	err = env.client.DeleteMachine("testcluster", "testmachine")
+	assert.NoError(t, err)
+
+	err = env.client.DeleteCluster("testcluster")
+	assert.NoError(t, err)
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/footloose/pkg/api"
+	"github.com/weaveworks/footloose/pkg/cluster"
 	"github.com/weaveworks/footloose/pkg/config"
 )
 
@@ -23,7 +24,8 @@ func newEnv() *env {
 	// Create an API server
 	server := httptest.NewUnstartedServer(nil)
 	baseURI := "http://" + server.Listener.Addr().String()
-	api := api.New(baseURI)
+	keyStore := cluster.NewKeyStore(".")
+	api := api.New(baseURI, keyStore)
 	server.Config.Handler = api.Router()
 	server.Start()
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -35,6 +35,27 @@ func newEnv() *env {
 	}
 }
 
+const publicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDT3IG4sRIpLaoAtQSXBYaVLZTXh3Pl95ONm9oe9+nJ08qrUOFEJuKMTnqSgbC+R6v3T6fcgu1HgZtQyqB15rlA5U6rybKEa631+2Y+STBdCtBover2/c59QqfEyXWoPeq0EWRCt/ixVJdcTZqxNpZQUBoUQAIl1T/+lqEsefI4H/fFCeuqDyZfjWQXpoIh8fTpYleS6rmzvKTBhxg149LdmI96mo8Wzh2nSuXxxrk4ItvjUkNP/+s/I1xBZ6OKkO5a1Ngjuv4Yi0HM3SwZcIEP4P8QnFJtTUZjz7NyyPUthJy7QPIRMmimCg+yyRwkMhnbb6bNY6QIbQmrRw4rbGyd31eY/xXXLk6DLVGaoacVD5VuPjSEVjn9lzgaQoO1HJLYnAfgJB+3L/eKG5C8iE4gwnNbKMazLr2iVa6VdeACqyzTyx3uv/4TY2Q3Aqq+LPzOda0nbeaeIaq6xpA1iBsdNM/j88SOGJtYufUngVMql7nZGsxHt4oEw0OOGtshWcR27bKMJsuOkghnHJzs9o9uRBvBStZFLpEyA6TEIeNfTn6Mzdag/T+0NeisXUKSEvrMaxEVAnX7uvkMr5UNUeT/TDbVhAtFHm4YDFEnSupmMsAKiuiTA+XhBuY+FzsGTDGcVZRj6ERZl6u0A+Oo8p/h7TizP3ct7dXVD02dmfJGAQ== cluster@footloose.mail"
+
+func TestCreateDeletePublicKey(t *testing.T) {
+	env := newEnv()
+	defer env.Close()
+
+	err := env.client.CreatePublicKey(&config.PublicKey{
+		Name: "testpublickey",
+		Key:  publicKey,
+	})
+	assert.NoError(t, err)
+
+	data, err := env.client.GetPublicKey("testpublickey")
+	assert.Equal(t, "testpublickey", data.Name)
+	assert.Equal(t, publicKey, data.Key)
+	assert.NoError(t, err)
+
+	err = env.client.DeletePublicKey("testpublickey")
+	assert.NoError(t, err)
+}
+
 func TestCreateDeleteCluster(t *testing.T) {
 	env := newEnv()
 	defer env.Close()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -92,6 +92,10 @@ func TestCreateDeleteMachine(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
+	status, err := env.client.GetMachine("testcluster", "testmachine")
+	assert.NoError(t, err)
+	assert.Equal(t, "testmachine", status.Spec.Name)
+
 	err = env.client.DeleteMachine("testcluster", "testmachine")
 	assert.NoError(t, err)
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -29,7 +29,8 @@ type Container struct {
 
 // Cluster is a running cluster.
 type Cluster struct {
-	spec config.Config
+	spec     config.Config
+	keyStore *KeyStore
 }
 
 // New creates a new cluster. It takes as input the description of the cluster

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -42,7 +42,7 @@ func New(conf config.Config) (*Cluster, error) {
 	}
 	return &Cluster{
 		spec:     conf,
-		keyStore: NewKeyStore("."),
+		keyStore: NewKeyStore("keys"),
 	}, nil
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -357,7 +357,7 @@ func (c *Cluster) machineFilering(machines []*Machine, hostnames []string) []*Ma
 	for _, machine := range hostnames {
 		machinesToKeep[machine] = false
 	}
-	// newMcahines is the filtered list
+	// newMachines is the filtered list
 	newMachines := make([]*Machine, 0)
 	for _, m := range machines {
 		if _, ok := machinesToKeep[m.hostname]; ok {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -41,8 +41,7 @@ func New(conf config.Config) (*Cluster, error) {
 		return nil, err
 	}
 	return &Cluster{
-		spec:     conf,
-		keyStore: NewKeyStore("keys"),
+		spec: conf,
 	}, nil
 }
 
@@ -64,6 +63,12 @@ func NewFromFile(path string) (*Cluster, error) {
 		return nil, err
 	}
 	return NewFromYAML(data)
+}
+
+// SetKeyStore provides a store where to persist public keys for this Cluster.
+func (c *Cluster) SetKeyStore(keyStore *KeyStore) *Cluster {
+	c.keyStore = keyStore
+	return c
 }
 
 // Name returns the cluster name.
@@ -179,7 +184,7 @@ touch $sshdir/authorized_keys; chmod 600 $sshdir/authorized_keys
 
 func (c *Cluster) publicKey(machine *Machine) ([]byte, error) {
 	// Prefer the machine public key over the cluster-wide key.
-	if machine.spec.PublicKey != "" {
+	if machine.spec.PublicKey != "" && c.keyStore != nil {
 		data, err := c.keyStore.Get(machine.spec.PublicKey)
 		if err != nil {
 			return nil, err

--- a/pkg/cluster/formatter.go
+++ b/pkg/cluster/formatter.go
@@ -73,7 +73,12 @@ func (JSONFormatter) Format(w io.Writer, machines []*Machine) error {
 
 // FormatSingle is a json formatter for a single machine.
 func (js JSONFormatter) FormatSingle(w io.Writer, m *Machine) error {
-	return js.Format(w, []*Machine{m})
+	status, err := json.MarshalIndent(m.Status(), "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(status)
+	return err
 }
 
 type tableMachine struct {

--- a/pkg/cluster/formatter.go
+++ b/pkg/cluster/formatter.go
@@ -67,6 +67,7 @@ func (JSONFormatter) Format(w io.Writer, machines []*Machine) error {
 	if err != nil {
 		return err
 	}
+	ms = append(ms, '\n')
 	_, err = w.Write(ms)
 	return err
 }

--- a/pkg/cluster/formatter.go
+++ b/pkg/cluster/formatter.go
@@ -67,8 +67,8 @@ func (JSONFormatter) Format(w io.Writer, machines []*Machine) error {
 	if err != nil {
 		return err
 	}
-	w.Write(ms)
-	return nil
+	_, err = w.Write(ms)
+	return err
 }
 
 // FormatSingle is a json formatter for a single machine.

--- a/pkg/cluster/key_store.go
+++ b/pkg/cluster/key_store.go
@@ -1,0 +1,71 @@
+package cluster
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// KeyStore is a store for public keys.
+type KeyStore struct {
+	basePath string
+}
+
+// NewKeyStore creates a new KeyStore
+func NewKeyStore(basePath string) *KeyStore {
+	return &KeyStore{
+		basePath: basePath,
+	}
+}
+
+func fileExists(path string) bool {
+	// XXX: There's a subtle bug: if stat fails for another reason that the file
+	// not existing, we return the file exists.
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func (s *KeyStore) keyPath(name string) string {
+	return filepath.Join(s.basePath, name)
+}
+
+func (s *KeyStore) keyExists(name string) bool {
+	return fileExists(s.keyPath(name))
+}
+
+// Store adds the key to the store.
+func (s *KeyStore) Store(name, key string) error {
+	if s.keyExists(name) {
+		return errors.Errorf("key '%s' already exists", name)
+	}
+
+	if err := ioutil.WriteFile(s.keyPath(name), []byte(key), 0644); err != nil {
+		return errors.Wrap(err, "store")
+	}
+
+	return nil
+}
+
+// Get retrieves a key from the store.
+func (s *KeyStore) Get(name string) ([]byte, error) {
+	if !s.keyExists(name) {
+		return nil, errors.Errorf("unknown key '%s'", name)
+	}
+	return ioutil.ReadFile(s.keyPath(name))
+}
+
+// Remove removes a key from the store.
+func (s *KeyStore) Remove(name string) error {
+	if !s.keyExists(name) {
+		return errors.Errorf("unknown key '%s'", name)
+	}
+	if err := os.Remove(s.keyPath(name)); err != nil {
+		return errors.Wrap(err, "remove")
+	}
+	return nil
+}

--- a/pkg/cluster/key_store.go
+++ b/pkg/cluster/key_store.go
@@ -41,11 +41,11 @@ func (s *KeyStore) keyExists(name string) bool {
 // Store adds the key to the store.
 func (s *KeyStore) Store(name, key string) error {
 	if s.keyExists(name) {
-		return errors.Errorf("key '%s' already exists", name)
+		return errors.Errorf("key store: store: key '%s' already exists", name)
 	}
 
 	if err := ioutil.WriteFile(s.keyPath(name), []byte(key), 0644); err != nil {
-		return errors.Wrap(err, "store")
+		return errors.Wrap(err, "key store: write")
 	}
 
 	return nil
@@ -54,7 +54,7 @@ func (s *KeyStore) Store(name, key string) error {
 // Get retrieves a key from the store.
 func (s *KeyStore) Get(name string) ([]byte, error) {
 	if !s.keyExists(name) {
-		return nil, errors.Errorf("unknown key '%s'", name)
+		return nil, errors.Errorf("key store: get: unknown key '%s'", name)
 	}
 	return ioutil.ReadFile(s.keyPath(name))
 }
@@ -62,10 +62,10 @@ func (s *KeyStore) Get(name string) ([]byte, error) {
 // Remove removes a key from the store.
 func (s *KeyStore) Remove(name string) error {
 	if !s.keyExists(name) {
-		return errors.Errorf("unknown key '%s'", name)
+		return errors.Errorf("key store: remove: unknown key '%s'", name)
 	}
 	if err := os.Remove(s.keyPath(name)); err != nil {
-		return errors.Wrap(err, "remove")
+		return errors.Wrap(err, "key store: remove")
 	}
 	return nil
 }

--- a/pkg/cluster/key_store.go
+++ b/pkg/cluster/key_store.go
@@ -20,6 +20,11 @@ func NewKeyStore(basePath string) *KeyStore {
 	}
 }
 
+// Init initializes the key store, creating the store directory if needed.
+func (s *KeyStore) Init() error {
+	return os.MkdirAll(s.basePath, 0760)
+}
+
 func fileExists(path string) bool {
 	// XXX: There's a subtle bug: if stat fails for another reason that the file
 	// not existing, we return the file exists.

--- a/pkg/cluster/key_store.go
+++ b/pkg/cluster/key_store.go
@@ -24,10 +24,7 @@ func fileExists(path string) bool {
 	// XXX: There's a subtle bug: if stat fails for another reason that the file
 	// not existing, we return the file exists.
 	_, err := os.Stat(path)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
+	return !os.IsNotExist(err)
 }
 
 func (s *KeyStore) keyPath(name string) string {

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -111,6 +111,7 @@ func (m *Machine) Status() *MachineStatus {
 	s.Image = m.spec.Image
 	s.Command = m.spec.Cmd
 	s.Spec = m.spec
+	s.Hostname = m.Hostname()
 	state := NotCreated
 	if m.IsCreated() {
 		state = Stopped

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -103,6 +103,41 @@ func (m *Machine) HostPort(containerPort int) (hostPort int, err error) {
 	return m.ports[containerPort], nil
 }
 
+// Status returns the machine status.
+func (m *Machine) Status() *MachineStatus {
+	s := MachineStatus{}
+
+	s.Container = m.ContainerName()
+	s.Image = m.spec.Image
+	s.Command = m.spec.Cmd
+	s.Spec = m.spec
+	state := NotCreated
+	if m.IsCreated() {
+		state = Stopped
+		if m.IsStarted() {
+			state = Running
+		}
+	}
+	s.State = state
+	var ports []port
+	for k, v := range m.ports {
+		p := port{
+			Host:  v,
+			Guest: k,
+		}
+		ports = append(ports, p)
+	}
+	if len(ports) < 1 {
+		for _, p := range m.spec.PortMappings {
+			ports = append(ports, port{Host: int(p.ContainerPort), Guest: 0})
+		}
+	}
+	s.Ports = ports
+	s.RuntimeNetworks = m.runtimeNetworks
+
+	return &s
+}
+
 // Only check for Ignite prerequisites once
 var igniteChecked bool
 

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -36,8 +36,11 @@ type Cluster struct {
 	Name string `json:"name"`
 
 	// PrivateKey is the path to the private SSH key used to login into the cluster
-	// machines. Can be expanded to user homedir if ~ is found. Ex. ~/.ssh/id_rsa
-	PrivateKey string `json:"privateKey"`
+	// machines. Can be expanded to user homedir if ~ is found. Ex. ~/.ssh/id_rsa.
+	//
+	// This field is optional. If absent, machines are expected to have a public
+	// key defined.
+	PrivateKey string `json:"privateKey,omitempty"`
 }
 
 // Config is the top level config object.

--- a/pkg/config/key.go
+++ b/pkg/config/key.go
@@ -1,0 +1,10 @@
+package config
+
+// PublicKey is a public SSH key.
+type PublicKey struct {
+	Name string `json:"name"`
+	// Key is the public key textual representation. Begins with Begins with
+	// 'ssh-rsa', 'ssh-dss', 'ssh-ed25519', 'ecdsa-sha2-nistp256',
+	// 'ecdsa-sha2-nistp384', or 'ecdsa-sha2-nistp521'.
+	Key string `json:"key"`
+}

--- a/pkg/config/machine.go
+++ b/pkg/config/machine.go
@@ -65,6 +65,10 @@ type Machine struct {
 	PortMappings []PortMapping `json:"portMappings,omitempty"`
 	// Cmd is a cmd which will be run in the container.
 	Cmd string `json:"cmd,omitempty"`
+	// PublicKey is the name of the public key to upload onto the machine for root
+	// SSH access.
+	PublicKey string `json:"publicKey,omitempty"`
+
 	// Backend specifies the runtime backend for this machine
 	Backend string `json:"backend,omitempty"`
 	// Ignite specifies ignite-specific options

--- a/pkg/config/machine.go
+++ b/pkg/config/machine.go
@@ -41,10 +41,14 @@ type PortMapping struct {
 
 // Machine is the machine configuration.
 type Machine struct {
-	// Name is the machine name. This is a format string with %d as the machine
-	// index, a number between 0 and N-1, N being the number of machines in the
-	// cluster. This name will also be used as the machine hostname. Defaults to
-	// "node%d".
+	// Name is the machine name.
+	//
+	// When used in a MachineReplicas object, eg. in footloose.yaml config files,
+	// this field a format string. This format string needs to have a '%d', which
+	// is populated by the machine index, a number between 0 and N-1, N being the
+	// Count field of MachineReplicas. Name will default to "node%d"
+	//
+	// This name will also be used as the machine hostname.
 	Name string `json:"name"`
 	// Image is the container image to use for this machine.
 	Image string `json:"image"`

--- a/serve.go
+++ b/serve.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/footloose/pkg/api"
@@ -46,12 +45,7 @@ func serve(cmd *cobra.Command, args []string) error {
 	}
 
 	api := api.New(baseURI)
-
-	router := mux.NewRouter()
-	router.HandleFunc("/api/clusters", api.CreateCluster).Methods("POST")
-	router.HandleFunc("/api/clusters/{cluster}", api.DeleteCluster).Methods("DELETE")
-	router.HandleFunc("/api/clusters/{cluster}/machines", api.CreateMachine).Methods("POST")
-	router.HandleFunc("/api/clusters/{cluster}/machines/{machine}", api.DeleteMachine).Methods("DELETE")
+	router := api.Router()
 
 	return http.ListenAndServe(opts.listen, router)
 }

--- a/serve.go
+++ b/serve.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/footloose/pkg/api"
+)
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Launch a footloose server",
+	RunE:  serve,
+}
+
+var serveOptions struct {
+	listen string
+}
+
+func baseURI(addr string) (string, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", err
+	}
+	if host == "" || host == "0.0.0.0" || host == "[::]" {
+		host = "localhost"
+	}
+	return fmt.Sprintf("http://%s:%s", host, port), nil
+}
+
+func init() {
+	serveCmd.Flags().StringVarP(&serveOptions.listen, "listen", "l", ":2444", "Cluster configuration file")
+	footloose.AddCommand(serveCmd)
+}
+
+func serve(cmd *cobra.Command, args []string) error {
+	opts := &serveOptions
+
+	baseURI, err := baseURI(opts.listen)
+	if err != nil {
+		return errors.Wrapf(err, "invalid listen address '%s'", opts.listen)
+	}
+
+	api := api.New(baseURI)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/api/clusters", api.CreateCluster).Methods("POST")
+	router.HandleFunc("/api/clusters/{cluster}", api.DeleteCluster).Methods("DELETE")
+	router.HandleFunc("/api/clusters/{cluster}/machines", api.CreateMachine).Methods("POST")
+	router.HandleFunc("/api/clusters/{cluster}/machines/{machine}", api.DeleteMachine).Methods("DELETE")
+
+	return http.ListenAndServe(opts.listen, router)
+}

--- a/serve_test.go
+++ b/serve_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBaseURI(t *testing.T) {
+	tests := []struct {
+		valid           bool
+		input, expected string
+	}{
+		{true, ":2444", "http://localhost:2444"},
+	}
+
+	for _, test := range tests {
+		uri, err := baseURI(test.input)
+		if !test.valid {
+			assert.Error(t, err)
+		}
+		assert.Equal(t, test.expected, uri)
+	}
+}

--- a/show.go
+++ b/show.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/weaveworks/footloose/pkg/cluster"
 )
@@ -40,5 +42,5 @@ func show(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return formatter.Format(machines)
+	return formatter.Format(os.Stdout, machines)
 }


### PR DESCRIPTION
At the moment, footloose is geared towards the command line. Turns out we'd like programs to create and delete clusters too.

This PR introduces `footloose serve` that will start such a server, defining a REST API that can be used by anyone. A go client is available in `pkg/client`.

**TODO**:
- [x] Add status API to get the machines runtime properties
- [x] Add a key API to upload public keys so they can be referred to when creating new clusters/machines.