### PR TITLE
Clean up the Ignite code, perform creation check before deleting a VM

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -300,15 +300,14 @@ func (c *Cluster) Create() error {
 
 func (c *Cluster) deleteMachine(machine *Machine, i int) error {
 	name := machine.ContainerName()
+	if !machine.IsCreated() {
+		log.Infof("Machine %s hasn't been created...", name)
+		return nil
+	}
 
 	if machine.IsIgnite() {
 		log.Infof("Deleting machine: %s ...", name)
 		return ignite.Remove(machine.name)
-	}
-
-	if !machine.IsCreated() {
-		log.Infof("Machine %s hasn't been created...", name)
-		return nil
 	}
 
 	if machine.IsStarted() {

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -109,10 +109,10 @@ func (m *Machine) HostPort(containerPort int) (hostPort int, err error) {
 }
 
 func (m *Machine) IsIgnite() (b bool) {
-	b = m.spec.Backend == ignite.IgniteName
+	b = m.spec.Backend == ignite.BackendName
 
 	if b && syscall.Getuid() != 0 {
-		log.Fatalf("Footloose needs to run as root to use the %q backend", ignite.IgniteName)
+		log.Fatalf("Footloose needs to run as root to use the %q backend", ignite.BackendName)
 	}
 
 	return

--- a/pkg/config/machine.go
+++ b/pkg/config/machine.go
@@ -75,29 +75,29 @@ func (m *Machine) IgniteConfig() Ignite {
 	if i.CPUs == 0 {
 		i.CPUs = 2
 	}
-	if i.Memory == "" {
+	if len(i.Memory) == 0 {
 		i.Memory = "1GB"
 	}
-	if i.Disk == "" {
+	if len(i.Disk) == 0 {
 		i.Disk = "4GB"
 	}
-	if i.Kernel == "" {
+	if len(i.Kernel) == 0 {
 		i.Kernel = "weaveworks/ignite-kernel:4.19.47"
 	}
 	return i
 }
 
-// Ignite holds ignite-specific config
+// Ignite holds the ignite-specific configuration
 type Ignite struct {
 	// CPUs specify the number of vCPUs to use. Default: 2
 	CPUs uint64 `json:"cpus,omitempty"`
 	// Memory specifies the amount of RAM the VM should have. Default: 1GB
 	Memory string `json:"memory,omitempty"`
-	// Disk specifies the amount of disk the VM should have. Default: 4GB
+	// Disk specifies the amount of disk space the VM should have. Default: 4GB
 	Disk string `json:"disk,omitempty"`
 	// Kernel specifies an OCI image to use for the kernel overlay
 	Kernel string `json:"kernel,omitempty"`
-	// Files to copy
+	// Files to copy to the VM
 	CopyFiles map[string]string `json:"copyFiles,omitempty"`
 }
 

--- a/pkg/ignite/inspect.go
+++ b/pkg/ignite/inspect.go
@@ -43,11 +43,12 @@ type VM struct {
 	Status   Status
 }
 
+// PopulateMachineDetails returns the details of the VM identified by the given name
 func PopulateMachineDetails(name string) (*VM, error) {
 	cmd := exec.Command(execName, "inspect", "vm", name)
 	lines, err := exec.CombinedOutputLines(cmd)
 	if err != nil {
-		log.Errorf("Ignite.IsStarted error:%v\n", err)
+		log.Errorf("Ignite.IsStarted error: %v\n", err)
 		return nil, err
 	}
 
@@ -55,15 +56,17 @@ func PopulateMachineDetails(name string) (*VM, error) {
 	for _, s := range lines {
 		sb.WriteString(s)
 	}
+
 	return toVM([]byte(sb.String()))
 }
 
+// toVM unmarshals the given data to a VM object
 func toVM(data []byte) (*VM, error) {
 	obj := &VM{}
-	err := json.Unmarshal(data, obj)
-	if err != nil {
-		log.Errorf("Ignite.toVM error:%v\n", err)
+	if err := json.Unmarshal(data, obj); err != nil {
+		log.Errorf("Ignite.toVM error: %v\n", err)
 		return nil, err
 	}
+
 	return obj, nil
 }

--- a/pkg/ignite/rm.go
+++ b/pkg/ignite/rm.go
@@ -2,11 +2,7 @@ package ignite
 
 import "github.com/weaveworks/footloose/pkg/exec"
 
+// Remove removes an Ignite VM
 func Remove(name string) error {
-	runArgs := []string{
-		"rm",
-		"-f",
-		name,
-	}
-	return exec.CommandWithLogging(execName, runArgs...)
+	return exec.CommandWithLogging(execName, "rm", "-f", name)
 }

--- a/pkg/ignite/start.go
+++ b/pkg/ignite/start.go
@@ -4,7 +4,7 @@ import (
 	"github.com/weaveworks/footloose/pkg/exec"
 )
 
-// Start starts a vm.
-func Start(vmname string) error {
-	return exec.Command(execName, "start", vmname).Run()
+// Start starts an Ignite VM
+func Start(name string) error {
+	return exec.CommandWithLogging(execName, "start", name)
 }

--- a/pkg/ignite/stop.go
+++ b/pkg/ignite/stop.go
@@ -4,7 +4,7 @@ import (
 	"github.com/weaveworks/footloose/pkg/exec"
 )
 
-// Stop stops a vm.
-func Stop(vmname string) error {
-	return exec.CommandWithLogging(execName, "stop", vmname)
+// Stop stops an Ignite VM
+func Stop(name string) error {
+	return exec.CommandWithLogging(execName, "stop", name)
 }


### PR DESCRIPTION
Fixes the creation check and nits of https://github.com/weaveworks/footloose/pull/190, also adds comments, improves code readability, and removes some duplicate code when fetching VM details.

cc @luxas 