### PR TITLE
Add a version check for Ignite, require v0.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/weaveworks/footloose
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -108,11 +108,19 @@ func (m *Machine) HostPort(containerPort int) (hostPort int, err error) {
 	return m.ports[containerPort], nil
 }
 
+// Only check for Ignite prerequisites once
+var igniteChecked bool
+
 func (m *Machine) IsIgnite() (b bool) {
 	b = m.spec.Backend == ignite.BackendName
 
-	if b && syscall.Getuid() != 0 {
-		log.Fatalf("Footloose needs to run as root to use the %q backend", ignite.BackendName)
+	if !igniteChecked && b {
+		if syscall.Getuid() != 0 {
+			log.Fatalf("Footloose needs to run as root to use the %q backend", ignite.BackendName)
+		}
+
+		ignite.CheckVersion()
+		igniteChecked = true
 	}
 
 	return

--- a/pkg/ignite/ignite.go
+++ b/pkg/ignite/ignite.go
@@ -1,5 +1,43 @@
 package ignite
 
-const (
-	execName = "ignite"
+import (
+	"fmt"
+
+	"github.com/blang/semver"
+	log "github.com/sirupsen/logrus"
+	"github.com/weaveworks/footloose/pkg/exec"
 )
+
+const execName = "ignite"
+
+var minVersion = semver.MustParse("0.5.2") // Require v0.5.2 or higher
+
+func CheckVersion() {
+
+	lines, err := exec.CombinedOutputLines(exec.Command(execName, "version", "-o", "short"))
+	if err == nil && len(lines) == 0 {
+		err = fmt.Errorf("no output")
+	}
+
+	if err != nil {
+		verParseFail(err)
+	}
+
+	// Use ParseTolerant as Ignite's version has a leading "v"
+	version, err := semver.ParseTolerant(lines[0])
+	if err != nil {
+		verParseFail(err)
+	}
+
+	if minVersion.Compare(version) > 0 {
+		verParseFail(fmt.Errorf("minimum version is v%s, detected older v%s", minVersion, version))
+	}
+
+	if len(version.Build) > 0 {
+		log.Warnf("Continuing with a dirty build of Ignite (v%s), here be dragons", version)
+	}
+}
+
+func verParseFail(err error) {
+	log.Fatalf("Failed to verify Ignite version: %v", err)
+}


### PR DESCRIPTION
Make Footloose require [v0.5.2](https://github.com/weaveworks/ignite/releases/tag/v0.5.2) of Ignite when using the Ignite backend.