### PR TITLE
Ignite backend: Fix VM disk size JSON tag to be "diskSize" following Ignite spec

### DIFF
--- a/pkg/config/machine.go
+++ b/pkg/config/machine.go
@@ -94,7 +94,7 @@ type Ignite struct {
 	// Memory specifies the amount of RAM the VM should have. Default: 1GB
 	Memory string `json:"memory,omitempty"`
 	// Disk specifies the amount of disk space the VM should have. Default: 4GB
-	Disk string `json:"disk,omitempty"`
+	Disk string `json:"diskSize,omitempty"`
 	// Kernel specifies an OCI image to use for the kernel overlay
 	Kernel string `json:"kernel,omitempty"`
 	// Files to copy to the VM

--- a/pkg/config/machine.go
+++ b/pkg/config/machine.go
@@ -78,8 +78,8 @@ func (m *Machine) IgniteConfig() Ignite {
 	if len(i.Memory) == 0 {
 		i.Memory = "1GB"
 	}
-	if len(i.Disk) == 0 {
-		i.Disk = "4GB"
+	if len(i.DiskSize) == 0 {
+		i.DiskSize = "4GB"
 	}
 	if len(i.Kernel) == 0 {
 		i.Kernel = "weaveworks/ignite-kernel:4.19.47"
@@ -93,8 +93,8 @@ type Ignite struct {
 	CPUs uint64 `json:"cpus,omitempty"`
 	// Memory specifies the amount of RAM the VM should have. Default: 1GB
 	Memory string `json:"memory,omitempty"`
-	// Disk specifies the amount of disk space the VM should have. Default: 4GB
-	Disk string `json:"diskSize,omitempty"`
+	// DiskSize specifies the amount of disk space the VM should have. Default: 4GB
+	DiskSize string `json:"diskSize,omitempty"`
 	// Kernel specifies an OCI image to use for the kernel overlay
 	Kernel string `json:"kernel,omitempty"`
 	// Files to copy to the VM

--- a/pkg/ignite/create.go
+++ b/pkg/ignite/create.go
@@ -25,7 +25,7 @@ func Create(name string, spec *config.Machine, pubKeyPath string) (id string, er
 		fmt.Sprintf("--name=%s", name),
 		fmt.Sprintf("--cpus=%d", spec.IgniteConfig().CPUs),
 		fmt.Sprintf("--memory=%s", spec.IgniteConfig().Memory),
-		fmt.Sprintf("--size=%s", spec.IgniteConfig().Disk),
+		fmt.Sprintf("--size=%s", spec.IgniteConfig().DiskSize),
 		fmt.Sprintf("--kernel-image=%s", spec.IgniteConfig().Kernel),
 		fmt.Sprintf("--ssh=%s", pubKeyPath),
 	}


### PR DESCRIPTION
Probably just a typo, the tag is `diskSize` instead of `disk` to be consistent with Ignite spec.

cc @luxas 