### PR TITLE
Add a Makefile, enable building Footloose in a Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cluster-key
 cluster-key.pub
 footloose
 /footloose.yaml
+/vendor

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+UID_GID?=$(shell id -u):$(shell id -g)
+GO_VERSION="1.12.6"
+
+all: binary
+
+binary: vendor
+	docker run -it --rm -v $(shell pwd):/build -w /build golang:${GO_VERSION} sh -c "\
+		make footloose && \
+		chown -R ${UID_GID} bin"
+
+footloose: bin/footloose
+bin/footloose:
+	CGO_ENABLED=0 go build -mod=vendor -o bin/footloose .
+
+.PHONY: bin/footloose
+
+vendor:
+	go mod vendor


### PR DESCRIPTION
The Makefile uses vendored dependencies to speed up the Docker build (no need to re-download on every build). Footloose doesn't include vendored dependencies in the source tree, so I added a gitignore entry for the `vendor` directory. That can be kept or removed based on people's opinions on keeping the `vendor` directory in-tree.