### PR TITLE
Ignite: update the README example to use diskSize instead of disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ machines:
   ignite:
     cpus: 2
     memory: 1GB
-    disk: 4GB
+    diskSize: 4GB
     kernel: weaveworks/ignite-ubuntu:4.19.47
 ```
 


### PR DESCRIPTION
Changes the Ignite example configuration in the README to use the recently renamed `diskSize`.

cc @luxas 