### PR TITLE
Adds RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,1 @@
+# Releasing Footloose

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,1 +1,2 @@
 # Releasing Footloose
+1. [ ] `README.md` update 4 references (two per link) of the version number in `Install.Linux` and `Install.macOS`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,2 +1,3 @@
 # Releasing Footloose
 1. [ ] `README.md` update 4 references (two per link) of the version number in `Install.Linux` and `Install.macOS`
+1. [ ] `examples/user-defined-network` update reference to version number in `Using user-defined network example`'s `cat footloose.yaml` output.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,3 +1,4 @@
 # Releasing Footloose
 1. [ ] `README.md` update 4 references (two per link) of the version number in `Install.Linux` and `Install.macOS`
 1. [ ] `examples/user-defined-network` update reference to version number in `Using user-defined network example`'s `cat footloose.yaml` output.
+1. [ ] `examples/user-defined-network/footloose.yaml` update image version number in `machines[0].spec.image


### PR DESCRIPTION
closes https://github.com/weaveworks/footloose/issues/205

(had time to work on this today while waiting for other things to spin up in the background)

I committed each item separately so you could take each on its own (or not).  I bet, now that we're looking at it, for the two related to the user-defined-network example it'd be fine if we just changed it to `:latest` and removed it from the list.  If you'd like me to do that and remove those two from the list I can happily and quickly do so.