### PR TITLE
version: Don't show version when build binary without ldflags

### DIFF
--- a/version.go
+++ b/version.go
@@ -23,6 +23,9 @@ var version = "git"
 
 func showVersion(cmd *cobra.Command, args []string) {
 	fmt.Println("version:", version)
+	if version == "git" {
+		return
+	}
 	release, err := release.FindLastRelease()
 	if err != nil {
 		fmt.Println("version: failed to check for new versions. You may want to check yourself at https://github.com/weaveworks/footloose/releases.")


### PR DESCRIPTION
Fix https://github.com/weaveworks/footloose/issues/209 