### PR TITLE
Fix documentation in examples/user-defined-network

### DIFF
--- a/examples/user-defined-network/README.md
+++ b/examples/user-defined-network/README.md
@@ -15,7 +15,8 @@ machines:
   spec:
     image: quay.io/footloose/centos7:0.6.2
     name: node%d
-    network: footloose-cluster
+    networks:
+    - footloose-cluster
     portMappings:
     - containerPort: 22
 ```

--- a/examples/user-defined-network/footloose.yaml
+++ b/examples/user-defined-network/footloose.yaml
@@ -6,6 +6,7 @@ machines:
   spec:
     image: quay.io/footloose/centos7:0.6.2
     name: node%d
-    network: footloose-cluster
+    networks:
+    - footloose-cluster
     portMappings:
     - containerPort: 22


### PR DESCRIPTION
The user-defined-network example doesn't work out of the box, from the looks of things this is because networks is an array.  I think this works, though!