### PR TITLE
Update: footloose serve

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,6 +1,11 @@
 package api
 
 import (
+	"encoding/json"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+
 	"github.com/gorilla/mux"
 	"github.com/weaveworks/footloose/pkg/cluster"
 )
@@ -10,28 +15,74 @@ type API struct {
 	BaseURI  string
 	db       db
 	keyStore *cluster.KeyStore
+	router   *mux.Router
 }
 
 // New creates a new object able to answer footloose REST API.
-func New(baseURI string, keyStore *cluster.KeyStore) *API {
+func New(baseURI string, keyStore *cluster.KeyStore, debug bool) *API {
+	if debug {
+		log.SetLevel(log.DebugLevel)
+	}
+
 	api := &API{
 		BaseURI:  baseURI,
 		keyStore: keyStore,
+		router:   mux.NewRouter(),
 	}
 	api.db.init()
 	return api
 }
 
+func httpLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Debugln(r.RequestURI, r.Method)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (a *API) createDocs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	response := map[string][]string{}
+
+	_ = a.router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		path, _ := route.GetPathTemplate()
+		methods, _ := route.GetMethods()
+
+		if _, ok := response[path]; ok {
+			response[path] = append(response[path], methods[0])
+		} else {
+			response[path] = methods
+		}
+
+		return nil
+	})
+
+	payload, err := json.Marshal(response)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	sendResponse(w, payload)
+}
+
+func (a *API) initRouter() {
+	a.router.HandleFunc("/api/keys", a.createPublicKey).Methods("POST")
+	a.router.HandleFunc("/api/keys/{key}", a.getPublicKey).Methods("GET")
+	a.router.HandleFunc("/api/keys/{key}", a.deletePublicKey).Methods("DELETE")
+	a.router.HandleFunc("/api/clusters", a.createCluster).Methods("POST")
+	a.router.HandleFunc("/api/clusters/{cluster}", a.deleteCluster).Methods("DELETE")
+	a.router.HandleFunc("/api/clusters/{cluster}/machines", a.createMachine).Methods("POST")
+	a.router.HandleFunc("/api/clusters/{cluster}/machines/{machine}", a.getMachine).Methods("GET")
+	a.router.HandleFunc("/api/clusters/{cluster}/machines/{machine}", a.deleteMachine).Methods("DELETE")
+
+	a.router.HandleFunc("/", a.createDocs).Methods("GET")
+
+	a.router.Use(httpLogger)
+}
+
 // Router returns the API request router.
 func (a *API) Router() *mux.Router {
-	router := mux.NewRouter()
-	router.HandleFunc("/api/keys", a.createPublicKey).Methods("POST")
-	router.HandleFunc("/api/keys/{key}", a.getPublicKey).Methods("GET")
-	router.HandleFunc("/api/keys/{key}", a.deletePublicKey).Methods("DELETE")
-	router.HandleFunc("/api/clusters", a.createCluster).Methods("POST")
-	router.HandleFunc("/api/clusters/{cluster}", a.deleteCluster).Methods("DELETE")
-	router.HandleFunc("/api/clusters/{cluster}/machines", a.createMachine).Methods("POST")
-	router.HandleFunc("/api/clusters/{cluster}/machines/{machine}", a.getMachine).Methods("GET")
-	router.HandleFunc("/api/clusters/{cluster}/machines/{machine}", a.deleteMachine).Methods("DELETE")
-	return router
+	a.initRouter()
+	return a.router
 }

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -9,6 +9,22 @@ func sendOK(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// DocsResponse returns basic API docs.
+type DocsResponse struct {
+	DOCS []byte `json:"docs"`
+}
+
+func sendResponse(w http.ResponseWriter, body []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	resp := DocsResponse{
+		DOCS: body,
+	}
+
+	_ = json.NewEncoder(w).Encode(&resp)
+}
+
 // ErrorResponse is the response API entry points return when they encountered an error.
 type ErrorResponse struct {
 	Error string `json:"error"`

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -25,7 +25,7 @@ func newEnv() *env {
 	server := httptest.NewUnstartedServer(nil)
 	baseURI := "http://" + server.Listener.Addr().String()
 	keyStore := cluster.NewKeyStore(".")
-	api := api.New(baseURI, keyStore)
+	api := api.New(baseURI, keyStore, false)
 	server.Config.Handler = api.Router()
 	server.Start()
 


### PR DESCRIPTION
While playing around, I added a few things.

##  made `serve` more talkative
   - added logger
     - to show it started, etc. (with the options provided)
     - in debug: it shows route matched
   - added --debug flag (which enables a little more output)

![image](https://user-images.githubusercontent.com/27003/73606392-1e1a0500-45aa-11ea-9e56-470e10b21121.png)

## api docs

 - added really simple "API docs"
 - all based on routes and methods for now

![image](https://user-images.githubusercontent.com/27003/73606385-0478bd80-45aa-11ea-94be-22ebf6e59644.png)