### PR TITLE
Remove docker volumes when machine is deleted

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -376,7 +376,7 @@ func (c *Cluster) DeleteMachine(machine *Machine, i int) error {
 			return err
 		}
 		cmd := exec.Command(
-			"docker", "rm", "-v",
+			"docker", "rm", "--volumes",
 			name,
 		)
 		return cmd.Run()

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -383,7 +383,7 @@ func (c *Cluster) DeleteMachine(machine *Machine, i int) error {
 	}
 	log.Infof("Deleting machine: %s ...", name)
 	cmd := exec.Command(
-		"docker", "rm", "-v",
+		"docker", "rm", "--volumes",
 		name,
 	)
 	return cmd.Run()

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -376,14 +376,14 @@ func (c *Cluster) DeleteMachine(machine *Machine, i int) error {
 			return err
 		}
 		cmd := exec.Command(
-			"docker", "rm",
+			"docker", "rm", "-v",
 			name,
 		)
 		return cmd.Run()
 	}
 	log.Infof("Deleting machine: %s ...", name)
 	cmd := exec.Command(
-		"docker", "rm",
+		"docker", "rm", "-v",
 		name,
 	)
 	return cmd.Run()


### PR DESCRIPTION
If the machine has an anonymous volume then we must give the `-v` flag when we delete the container, otherwise the volume is leaked.