### PR TITLE
fix(build): Fix goreleaser deprecated field in config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,7 @@ changelog:
     - '^test:'
 brews:
   -
-    github:
+    tap:
       owner: weaveworks
       name: homebrew-tap
     commit_author:


### PR DESCRIPTION
This PR is to fix error in .goreleaser.yaml due to deprecated field.

Signed-off-by: Tam Mach <sayboras@yahoo.com>

/cc @chanwit 

Testing was done locally as per below. Related docs https://goreleaser.com/deprecations#brewsgithub

<details>
<summary>Before</summary>

```
$ goreleaser check -f .goreleaser.yml

   • loading config file       file=.goreleaser.yml
   • checking config: 
      • snapshotting     
      • github/gitlab/gitea releases
      • project name     
      • building binaries
      • creating source archive
      • archives         
      • linux packages   
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • docker images    
      • artifactory      
      • blobs            
      • homebrew tap formula
         • optimistically guessing `brew[0].installs`, double check
            • DEPRECATED: `brews.github` should not be used anymore, check https://goreleaser.com/deprecations#brewsgithub for more info.
      • scoop manifests  
      • milestones       
   ⨯ command failed            error=config is valid, but uses deprecated properties, check logs above for details
```

</details>

<details>
<summary>After</summary>

```
$ goreleaser check -f .goreleaser.yml

   • loading config file       file=.goreleaser.yml
   • checking config: 
      • snapshotting     
      • github/gitlab/gitea releases
      • project name     
      • building binaries
      • creating source archive
      • archives         
      • linux packages   
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • docker images    
      • artifactory      
      • blobs            
      • homebrew tap formula
         • optimistically guessing `brew[0].installs`, double check
      • scoop manifests  
      • milestones       
   • config is valid  

```

</details>