### PR TITLE
Fixes issue 270: footloose container fails to start after upgrading t…

### DIFF
--- a/images/debian11/Dockerfile
+++ b/images/debian11/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:bullseye
+
+ENV container docker
+
+# Don't start any optional services except for the few we need.
+RUN find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \;
+
+RUN apt-get update && \
+    apt-get install -y \
+    dbus systemd openssh-server net-tools iproute2 iputils-ping curl wget vim-tiny sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 22
+
+RUN systemctl set-default multi-user.target
+RUN systemctl mask \
+    dev-hugepages.mount \
+    sys-fs-fuse-connections.mount \
+    systemd-update-utmp.service \
+    systemd-tmpfiles-setup.service \
+    console-getty.service
+
+# This container image doesn't have locales installed. Disable forwarding the
+# user locale env variables or we get warnings such as:
+#  bash: warning: setlocale: LC_ALL: cannot change locale
+RUN sed -i -e 's/^AcceptEnv LANG LC_\*$/#AcceptEnv LANG LC_*/' /etc/ssh/sshd_config
+
+# https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/
+STOPSIGNAL SIGRTMIN+3
+
+CMD ["/bin/bash"]

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -294,7 +294,8 @@ func (c *Cluster) createMachineRunArgs(machine *Machine, name string, i int) []s
 		"--tmpfs", "/run",
 		"--tmpfs", "/run/lock",
 		"--tmpfs", "/tmp:exec,mode=777",
-		"-v", "/sys/fs/cgroup:/sys/fs/cgroup:ro",
+		"--cgroupns", "host",
+		"-v", "/sys/fs/cgroup:/sys/fs/cgroup:rw",
 	}
 
 	for _, volume := range machine.spec.Volumes {


### PR DESCRIPTION
…o Docker 4.3

According to https://docs.docker.com/desktop/mac/release-notes/#bug-fixes-and-minor-changes-1
- Add the following option:
  --cgroupns=host
- Modifies volume option:
  -v /sys/fs/cgroup:/sys/fs/cgroup:rw.

Adds a debian11 image that uses systemd 247