### PR TITLE
Fix download binary path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ about it is: [Vagrant](https://www.vagrantup.com/), but with containers.
 ### Linux
 
 ```console
-curl -Lo footloose https://github.com/weaveworks/footloose/releases/download/0.6.4/footloose-0.6.4-linux-x86_64
+curl -Lo footloose https://github.com/weaveworks/footloose/releases/download/0.6.3/footloose-0.6.3-linux-x86_64
 chmod +x footloose
 sudo mv footloose /usr/local/bin/
 ```
@@ -36,7 +36,7 @@ sudo mv footloose /usr/local/bin/
 On macOS we provide a direct download and a homebrew tap:
 
 ```console
-curl --silent --location https://github.com/weaveworks/footloose/releases/download/0.6.4/footloose-0.6.4-darwin-x86_64.tar.gz | tar xz
+curl --silent --location https://github.com/weaveworks/footloose/releases/download/0.6.3/footloose-0.6.3-darwin-x86_64.tar.gz | tar xz
 sudo mv footloose /usr/local/bin
 ```
 


### PR DESCRIPTION
A bit of a nitpick, but since release 0.6.4 is not yet released, the installation instructions as of now, do not work and the URL need to be amended.
This PR fixes the link to point to release 0.6.3 instead.