### PR TITLE
Fixed cgroups issue and added "user" in machine spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 cluster-key
 cluster-key.pub
 footloose
+.vscode

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 // indirect
+	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
 

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -25,6 +25,8 @@ type Machine struct {
 	hostname string
 	// container ip.
 	ip string
+	// container user.
+	user string
 
 	runtimeNetworks []*RuntimeNetwork
 	// Fields that are cached from the docker daemon.
@@ -50,6 +52,17 @@ func (m *Machine) ContainerName() string {
 // Hostname is the machine hostname.
 func (m *Machine) Hostname() string {
 	return m.hostname
+}
+
+// defaultUser is the default container user.
+const defaultUser = "root"
+
+// User gets the machine's OS user, defaults to root if not specified.
+func (m *Machine) User() string {
+	if m.user == "" {
+		return defaultUser
+	}
+	return m.user
 }
 
 // IsCreated returns if a machine is has been created. A created machine could

--- a/ssh.go
+++ b/ssh.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"os/user"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -43,11 +42,11 @@ func ssh(cmd *cobra.Command, args []string) error {
 		node = items[1]
 	} else {
 		node = args[0]
-		user, err := user.Current()
+		machine, err := cluster.GetMachineByHostname(node)
 		if err != nil {
-			return errors.New("error in getting current user")
+			return fmt.Errorf("host not found: %s", node)
 		}
-		username = user.Username
+		username = machine.User()
 	}
 	return cluster.SSH(node, username, args[1:]...)
 }


### PR DESCRIPTION
Two changes were made in this PR:
- Fixed (or worked around) an issue in `cgroups` v2 enabled Docker, say in `v20.10+`, and maybe `containerd`;
- Added (optional) "user" in machine spec.


Actually, there are some stories behind this PR. I recently changed my Macbook Pro from Intel to M1 chip and replaced Docker Desktop with Rancher Desktop. When I was trying to run `footloose` again, it failed in `footloose ssh` command so I dug into the code and found 2 issues:

### 1. The `systemd` was broken so the `sshd` was not up and running.

This worried me as there might be a couple of possibilities:
- We need to build very specific Docker images for Docker on Mac with M1 chip;
- The `systemd` has issues running on Mac with M1 chip.

So I reached out with this issue reported: https://github.com/weaveworks/footloose/issues/274
But it turns out that it's because of `cgroups` compatibility related issue: My Docker is on `v20.10.16` and `cgroups` should be on v2 already.
Somebody had mentioned it here: https://github.com/systemd/systemd/issues/19245
The fix, or workaround, is very simple: remove the read-only `/sys/fs/cgroup` mount in the startup command which is hardcoded in `cluster.go` and it then works.

For those who want to continue the backward compatibility, they may need to define it explicitly in the `machines[].spec.volumes`.
We may need to document it if there is a need.

### 2. The `footloose ssh` needs to specify the user explicitly.

The current code's logic is to get the "current user" of OS where `footloose` commands are run, which may not make sense in most of the cases.
For example, in my Mac the default user is my name while the container might be using `root`.
So specifying `footloose ssh root@node` might not be the best UX.

I raised it here: https://github.com/weaveworks/footloose/issues/276

What this PR provides is to extend a new (but optional) element, namely `user`, to specify the machine's user, if there is a need, and it defaults to the commonly used user `root` if nothing is set.
So it has backward compatibility while offering more flexibility.

